### PR TITLE
cmd/search/grep: Change '--color never' -> '--color=never'

### DIFF
--- a/cmd/search/grep.go
+++ b/cmd/search/grep.go
@@ -75,7 +75,7 @@ type grepGenerator struct {
 }
 
 func (g grepGenerator) Command(index *Index) (string, []string) {
-	args := []string{g.execPath, "--color", "never", "-R", "--null"}
+	args := []string{g.execPath, "--color=never", "-R", "--null"}
 	if index.Context >= 0 {
 		args = append(args, "--context", strconv.Itoa(index.Context))
 	} else {


### PR DESCRIPTION
My RHEL 7.5 CSB has:

```console
$ grep --version | head -n1
grep (GNU grep) 2.20
```

which treats `--color never` as "regexp `never` and also the `--color` option", not "the `--color` option with the value `never`".  For example:

```console
$ echo 'well I never' >test
$ grep --color never well test
grep: well: No such file or directory
test:well I never
$ grep --color=never well test
well I never
```

Even [the current 3.3 docs talk about `--color=WHEN`][1], so going with the single-argv form should be forward compatible (at least across a broad range of GNU releases; these options aren't in [POSIX][2]).

[1]: https://www.gnu.org/software/grep/manual/html_node/General-Output-Control.html#General-Output-Control
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html