### PR TITLE
cmd/search: Add /search for JSON search results

### DIFF
--- a/cmd/search/grep.go
+++ b/cmd/search/grep.go
@@ -7,13 +7,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"sort"
 	"strconv"
-	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -28,22 +23,9 @@ type Index struct {
 	MaxAge time.Duration
 }
 
-type Result struct {
-	FailedAt time.Time
-}
-
-type ResultMetadata interface {
-	MetadataFor(path string) (Result, bool)
-}
-
 type CommandGenerator interface {
 	Command(*Index) (cmd string, args []string)
 	PathPrefix() string
-}
-
-type PathAccessor interface {
-	SearchPaths(*Index, []string) []string
-	Stats() PathIndexStats
 }
 
 type ripgrepGenerator struct {
@@ -243,146 +225,4 @@ func executeGrep(ctx context.Context, gen CommandGenerator, index *Index, maxLin
 			}
 		}
 	}
-}
-
-type pathIndex struct {
-	base   string
-	maxAge time.Duration
-
-	lock      sync.Mutex
-	ordered   []pathAge
-	stats     PathIndexStats
-	pathIndex map[string]int
-}
-
-type PathIndexStats struct {
-	Entries int
-	Size    int64
-}
-
-type pathAge struct {
-	path  string
-	index string
-	age   time.Time
-}
-
-func (index *pathIndex) MetadataFor(path string) (Result, bool) {
-	var age time.Time
-	var ok bool
-	index.lock.Lock()
-	position, ok := index.pathIndex[path]
-	if ok {
-		age = index.ordered[position].age
-	}
-	index.lock.Unlock()
-	if !ok {
-		return Result{}, false
-	}
-	return Result{FailedAt: age}, true
-}
-
-func (index *pathIndex) Load() error {
-	ordered := make([]pathAge, 0, 1024)
-
-	var err error
-	start := time.Now()
-	defer func() {
-		glog.Infof("Refreshed path index in %s, loaded %d: %v", time.Now().Sub(start).Truncate(time.Millisecond), len(ordered), err)
-	}()
-
-	mustExpire := index.maxAge != 0
-	expiredAt := start.Add(-index.maxAge)
-
-	stats := PathIndexStats{}
-
-	err = filepath.Walk(index.base, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-		if mustExpire && expiredAt.After(info.ModTime()) {
-			os.RemoveAll(path)
-			return nil
-		}
-		if info.IsDir() {
-			return nil
-		}
-		switch info.Name() {
-		case "build-log.txt":
-			stats.Entries++
-			stats.Size += info.Size()
-			ordered = append(ordered, pathAge{index: "build-log", path: path, age: info.ModTime()})
-		case "junit.failures":
-			stats.Entries++
-			stats.Size += info.Size()
-			ordered = append(ordered, pathAge{index: "junit", path: path, age: info.ModTime()})
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	sort.Slice(ordered, func(i, j int) bool { return ordered[i].age.After(ordered[j].age) })
-	pathIndex := make(map[string]int, len(ordered))
-	for i, item := range ordered {
-		path := strings.TrimPrefix(item.path, index.base)
-		pathIndex[path] = i
-	}
-
-	index.lock.Lock()
-	defer index.lock.Unlock()
-	index.ordered = ordered
-	index.pathIndex = pathIndex
-	index.stats = stats
-
-	return nil
-}
-
-func (i *pathIndex) Stats() PathIndexStats {
-	i.lock.Lock()
-	defer i.lock.Unlock()
-	return i.stats
-}
-
-func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
-	var paths []pathAge
-	i.lock.Lock()
-	paths = i.ordered
-	i.lock.Unlock()
-
-	// search all if we haven't built an index yet
-	if len(paths) == 0 {
-		return append(initial, i.base)
-	}
-
-	// grow the map to the desired size up front
-	if len(paths) > len(initial) {
-		copied := make([]string, len(initial), len(initial)+len(paths))
-		copy(copied, initial)
-		initial = copied
-	}
-
-	all := len(index.SearchType) == 0 || index.SearchType == "all"
-
-	if index.MaxAge > 0 {
-		oldest := time.Now().Add(-index.MaxAge)
-		for _, path := range paths {
-			if path.age.Before(oldest) {
-				break
-			}
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
-		}
-	} else {
-		for _, path := range paths {
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
-		}
-	}
-	return initial
 }

--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -202,7 +201,6 @@ func renderWithContext(ctx context.Context, w http.ResponseWriter, index *Index,
 		if count == 5 || count%50 == 0 {
 			bw.Flush()
 		}
-		name = strings.Trim(name, "/")
 		if lastName == name {
 			fmt.Fprintf(bw, "\n&mdash;\n\n")
 		} else {
@@ -220,7 +218,7 @@ func renderWithContext(ctx context.Context, w http.ResponseWriter, index *Index,
 			}
 
 			fmt.Fprintf(bw, `<div class="mb-4">`)
-			parts := bytes.SplitN([]byte(name), []byte{filepath.Separator}, 8)
+			parts := bytes.SplitN([]byte(name), []byte("/"), 8)
 			last := len(parts) - 1
 			switch {
 			case last > 2 && (bytes.Equal(parts[last], []byte("junit.failures")) || bytes.Equal(parts[last], []byte("build-log.txt"))):
@@ -287,7 +285,6 @@ func renderSummary(ctx context.Context, w http.ResponseWriter, index *Index, gen
 		if count == 5 || count%50 == 0 {
 			bw.Flush()
 		}
-		name = strings.Trim(name, "/")
 		if lastName == name {
 			// continue accumulating matches
 		} else {
@@ -308,7 +305,7 @@ func renderSummary(ctx context.Context, w http.ResponseWriter, index *Index, gen
 			}
 
 			fmt.Fprintf(bw, `<tr>`)
-			parts := bytes.SplitN([]byte(name), []byte{filepath.Separator}, 8)
+			parts := bytes.SplitN([]byte(name), []byte("/"), 8)
 			last := len(parts) - 1
 			switch {
 			case last > 2 && (bytes.Equal(parts[last], []byte("junit.failures")) || bytes.Equal(parts[last], []byte("build-log.txt"))):

--- a/cmd/search/job.go
+++ b/cmd/search/job.go
@@ -22,16 +22,16 @@ type ProwJob struct {
 	BuildID  string `json:"build_id"`
 }
 
-func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL) error {
+func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL, jobURIPrefix *url.URL) error {
 	date, err := time.Parse(time.RFC3339, job.Finished)
 	if err != nil {
 		return fmt.Errorf("prow job %s #%s had invalid date: %s", job.Job, job.BuildID, err)
 	}
 	logPath := job.URL
-	if !strings.HasPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/") {
+	if !strings.HasPrefix(logPath, jobURIPrefix.String()) {
 		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
 	}
-	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
+	logPath = path.Join(strings.TrimPrefix(logPath, jobURIPrefix.String()), "build-log.txt")
 	if _, ok := indexedPaths.MetadataFor(logPath); ok {
 		return nil
 	}

--- a/cmd/search/job.go
+++ b/cmd/search/job.go
@@ -32,7 +32,7 @@ func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir 
 		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
 	}
 	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
-	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
+	if _, ok := indexedPaths.MetadataFor(logPath); ok {
 		return nil
 	}
 
@@ -55,7 +55,7 @@ func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir 
 		}
 		return fmt.Errorf("unable to query prow job logs %s: %d %s", logsURL.String(), resp.StatusCode, resp.Status)
 	}
-	pathOnDisk := filepath.Join(append([]string{toDir}, strings.Split(logPath, "/")...)...)
+	pathOnDisk := filepath.Join(toDir, filepath.FromSlash(logPath))
 	parent := filepath.Dir(pathOnDisk)
 	if err := os.MkdirAll(parent, 0777); err != nil {
 		return fmt.Errorf("unable to create directory for prow job index: %v", err)

--- a/cmd/search/job.go
+++ b/cmd/search/job.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type ProwJob struct {
+	Type     string `json:"type"`
+	State    string `json:"state"`
+	URL      string `json:"url"`
+	Finished string `json:"finished"`
+	Job      string `json:"job"`
+	BuildID  string `json:"build_id"`
+}
+
+func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL) error {
+	date, err := time.Parse(time.RFC3339, job.Finished)
+	if err != nil {
+		return fmt.Errorf("prow job %s #%s had invalid date: %s", job.Job, job.BuildID, err)
+	}
+	logPath := job.URL
+	if !strings.HasPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/") {
+		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
+	}
+	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
+	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
+		return nil
+	}
+
+	logsURL := *deckURL
+	logsURL.Path = "/log"
+	query := url.Values{"id": []string{job.BuildID}, "job": []string{job.Job}}
+	logsURL.RawQuery = query.Encode()
+	resp, err := client.Get(logsURL.String())
+	if err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck: %v", err)
+	}
+	defer func() {
+		// ensure we pull the body completely so connections are reused
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode == 404 {
+			return nil
+		}
+		return fmt.Errorf("unable to query prow job logs %s: %d %s", logsURL.String(), resp.StatusCode, resp.Status)
+	}
+	pathOnDisk := filepath.Join(append([]string{toDir}, strings.Split(logPath, "/")...)...)
+	parent := filepath.Dir(pathOnDisk)
+	if err := os.MkdirAll(parent, 0777); err != nil {
+		return fmt.Errorf("unable to create directory for prow job index: %v", err)
+	}
+	f, err := os.OpenFile(pathOnDisk, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck, could not create log file: %v", err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck, could not copy log file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck, could not close log file: %v", err)
+	}
+	if err := os.Chtimes(pathOnDisk, date, date); err != nil {
+		return fmt.Errorf("unable to set file time while indexing to disk: %v", err)
+	}
+	return nil
+}

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -100,6 +100,7 @@ func (o *options) Run() error {
 	if len(o.ListenAddr) > 0 {
 		mux := mux.NewRouter()
 		mux.HandleFunc("/config", o.handleConfig)
+		mux.HandleFunc("/search", o.handleSearch)
 		mux.HandleFunc("/", o.handleIndex)
 
 		go func() {

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -4,14 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -259,68 +257,4 @@ func (o *options) Run() error {
 	}
 
 	select {}
-}
-
-type ProwJob struct {
-	Type     string `json:"type"`
-	State    string `json:"state"`
-	URL      string `json:"url"`
-	Finished string `json:"finished"`
-	Job      string `json:"job"`
-	BuildID  string `json:"build_id"`
-}
-
-func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL) error {
-	date, err := time.Parse(time.RFC3339, job.Finished)
-	if err != nil {
-		return fmt.Errorf("prow job %s #%s had invalid date: %s", job.Job, job.BuildID, err)
-	}
-	logPath := job.URL
-	if !strings.HasPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/") {
-		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
-	}
-	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
-	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
-		return nil
-	}
-
-	logsURL := *deckURL
-	logsURL.Path = "/log"
-	query := url.Values{"id": []string{job.BuildID}, "job": []string{job.Job}}
-	logsURL.RawQuery = query.Encode()
-	resp, err := client.Get(logsURL.String())
-	if err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck: %v", err)
-	}
-	defer func() {
-		// ensure we pull the body completely so connections are reused
-		io.Copy(ioutil.Discard, resp.Body)
-		resp.Body.Close()
-	}()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if resp.StatusCode == 404 {
-			return nil
-		}
-		return fmt.Errorf("unable to query prow job logs %s: %d %s", logsURL.String(), resp.StatusCode, resp.Status)
-	}
-	pathOnDisk := filepath.Join(append([]string{toDir}, strings.Split(logPath, "/")...)...)
-	parent := filepath.Dir(pathOnDisk)
-	if err := os.MkdirAll(parent, 0777); err != nil {
-		return fmt.Errorf("unable to create directory for prow job index: %v", err)
-	}
-	f, err := os.OpenFile(pathOnDisk, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck, could not create log file: %v", err)
-	}
-	defer f.Close()
-	if _, err := io.Copy(f, resp.Body); err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck, could not copy log file: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck, could not close log file: %v", err)
-	}
-	if err := os.Chtimes(pathOnDisk, date, date); err != nil {
-		return fmt.Errorf("unable to set file time while indexing to disk: %v", err)
-	}
-	return nil
 }

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+type PathAccessor interface {
+	SearchPaths(*Index, []string) []string
+	Stats() PathIndexStats
+}
+
+type PathIndexStats struct {
+	Entries int
+	Size    int64
+}
+
+type Result struct {
+	FailedAt time.Time
+}
+
+type ResultMetadata interface {
+	MetadataFor(path string) (Result, bool)
+}
+
+type pathIndex struct {
+	base   string
+	maxAge time.Duration
+
+	lock      sync.Mutex
+	ordered   []pathAge
+	stats     PathIndexStats
+	pathIndex map[string]int
+}
+
+type pathAge struct {
+	path  string
+	index string
+	age   time.Time
+}
+
+func (index *pathIndex) MetadataFor(path string) (Result, bool) {
+	var age time.Time
+	var ok bool
+	index.lock.Lock()
+	position, ok := index.pathIndex[path]
+	if ok {
+		age = index.ordered[position].age
+	}
+	index.lock.Unlock()
+	if !ok {
+		return Result{}, false
+	}
+	return Result{FailedAt: age}, true
+}
+
+func (index *pathIndex) Load() error {
+	ordered := make([]pathAge, 0, 1024)
+
+	var err error
+	start := time.Now()
+	defer func() {
+		glog.Infof("Refreshed path index in %s, loaded %d: %v", time.Now().Sub(start).Truncate(time.Millisecond), len(ordered), err)
+	}()
+
+	mustExpire := index.maxAge != 0
+	expiredAt := start.Add(-index.maxAge)
+
+	stats := PathIndexStats{}
+
+	err = filepath.Walk(index.base, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if mustExpire && expiredAt.After(info.ModTime()) {
+			os.RemoveAll(path)
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		switch info.Name() {
+		case "build-log.txt":
+			stats.Entries++
+			stats.Size += info.Size()
+			ordered = append(ordered, pathAge{index: "build-log", path: path, age: info.ModTime()})
+		case "junit.failures":
+			stats.Entries++
+			stats.Size += info.Size()
+			ordered = append(ordered, pathAge{index: "junit", path: path, age: info.ModTime()})
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].age.After(ordered[j].age) })
+	pathIndex := make(map[string]int, len(ordered))
+	for i, item := range ordered {
+		path := strings.TrimPrefix(item.path, index.base)
+		pathIndex[path] = i
+	}
+
+	index.lock.Lock()
+	defer index.lock.Unlock()
+	index.ordered = ordered
+	index.pathIndex = pathIndex
+	index.stats = stats
+
+	return nil
+}
+
+func (i *pathIndex) Stats() PathIndexStats {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return i.stats
+}
+
+func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
+	var paths []pathAge
+	i.lock.Lock()
+	paths = i.ordered
+	i.lock.Unlock()
+
+	// search all if we haven't built an index yet
+	if len(paths) == 0 {
+		return append(initial, i.base)
+	}
+
+	// grow the map to the desired size up front
+	if len(paths) > len(initial) {
+		copied := make([]string, len(initial), len(initial)+len(paths))
+		copy(copied, initial)
+		initial = copied
+	}
+
+	all := len(index.SearchType) == 0 || index.SearchType == "all"
+
+	if index.MaxAge > 0 {
+		oldest := time.Now().Add(-index.MaxAge)
+		for _, path := range paths {
+			if path.age.Before(oldest) {
+				break
+			}
+			if all || path.index == index.SearchType {
+				initial = append(initial, path.path)
+			}
+		}
+	} else {
+		for _, path := range paths {
+			if all || path.index == index.SearchType {
+				initial = append(initial, path.path)
+			}
+		}
+	}
+	return initial
+}

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -146,21 +146,17 @@ func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
 
 	all := len(index.SearchType) == 0 || index.SearchType == "all"
 
+	var oldest time.Time
 	if index.MaxAge > 0 {
-		oldest := time.Now().Add(-index.MaxAge)
-		for _, path := range paths {
-			if path.age.Before(oldest) {
-				break
-			}
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
+		oldest = time.Now().Add(-index.MaxAge)
+	}
+
+	for _, path := range paths {
+		if path.age.Before(oldest) {
+			break
 		}
-	} else {
-		for _, path := range paths {
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
+		if all || path.index == index.SearchType {
+			initial = append(initial, path.path)
 		}
 	}
 	return initial

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/glog"
+)
+
+func (o *options) handleSearch(w http.ResponseWriter, req *http.Request) {
+	index, err := o.parseRequest(req)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Bad input: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	if len(index.Search) == 0 {
+		http.Error(w, "The 'search' query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	result := map[string]map[string][]*Match{}
+
+	err = executeGrep(req.Context(), o.generator, index, 30, func(name string, search string, matches []bytes.Buffer, moreLines int) {
+		metadata, _ := o.metadata.MetadataFor(name)
+
+		if metadata.JobURI == nil {
+			glog.Errorf("Failed to compute job URI for %q", name)
+			return
+		}
+		uri := metadata.JobURI.String()
+		_, ok := result[uri]
+		if !ok {
+			result[uri] = make(map[string][]*Match, 1)
+		}
+
+		_, ok = result[uri][search]
+		if !ok {
+			result[uri][search] = make([]*Match, 0, 1)
+		}
+
+		match := &Match{
+			FileType:  metadata.FileType,
+			MoreLines: moreLines,
+		}
+
+		for _, m := range matches {
+			line := bytes.TrimRight(m.Bytes(), " ")
+			match.Context = append(match.Context, string(line))
+		}
+		result[uri][search] = append(result[uri][search], match)
+	})
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed search: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Unable to serialize result: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}


### PR DESCRIPTION
Builds on #11; review that first.

This is an initial pass at the JSON API that I use [here][1] for my D3 failure charts.  Including it here will get us closer to allowing folks to generate those plots without having to pull down local copies of the logs being searched.  It's a WIP, because there are a number of FIXMEs in the code for bits that I haven't worked out yet, but I thought it was far enough along to be worth a PR ;).

[1]: https://github.com/wking/openshift-release/blob/e32d528649495063268d07bb782b8d26e59b685b/d3/server#L76-L85