### PR TITLE
cmd/search: Add --job-uri-prefix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cmd/search/grep.go
+++ b/cmd/search/grep.go
@@ -7,13 +7,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"sort"
 	"strconv"
-	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -28,22 +23,9 @@ type Index struct {
 	MaxAge time.Duration
 }
 
-type Result struct {
-	FailedAt time.Time
-}
-
-type ResultMetadata interface {
-	MetadataFor(path string) (Result, bool)
-}
-
 type CommandGenerator interface {
 	Command(*Index) (cmd string, args []string)
 	PathPrefix() string
-}
-
-type PathAccessor interface {
-	SearchPaths(*Index, []string) []string
-	Stats() PathIndexStats
 }
 
 type ripgrepGenerator struct {
@@ -243,146 +225,4 @@ func executeGrep(ctx context.Context, gen CommandGenerator, index *Index, maxLin
 			}
 		}
 	}
-}
-
-type pathIndex struct {
-	base   string
-	maxAge time.Duration
-
-	lock      sync.Mutex
-	ordered   []pathAge
-	stats     PathIndexStats
-	pathIndex map[string]int
-}
-
-type PathIndexStats struct {
-	Entries int
-	Size    int64
-}
-
-type pathAge struct {
-	path  string
-	index string
-	age   time.Time
-}
-
-func (index *pathIndex) MetadataFor(path string) (Result, bool) {
-	var age time.Time
-	var ok bool
-	index.lock.Lock()
-	position, ok := index.pathIndex[path]
-	if ok {
-		age = index.ordered[position].age
-	}
-	index.lock.Unlock()
-	if !ok {
-		return Result{}, false
-	}
-	return Result{FailedAt: age}, true
-}
-
-func (index *pathIndex) Load() error {
-	ordered := make([]pathAge, 0, 1024)
-
-	var err error
-	start := time.Now()
-	defer func() {
-		glog.Infof("Refreshed path index in %s, loaded %d: %v", time.Now().Sub(start).Truncate(time.Millisecond), len(ordered), err)
-	}()
-
-	mustExpire := index.maxAge != 0
-	expiredAt := start.Add(-index.maxAge)
-
-	stats := PathIndexStats{}
-
-	err = filepath.Walk(index.base, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-		if mustExpire && expiredAt.After(info.ModTime()) {
-			os.RemoveAll(path)
-			return nil
-		}
-		if info.IsDir() {
-			return nil
-		}
-		switch info.Name() {
-		case "build-log.txt":
-			stats.Entries++
-			stats.Size += info.Size()
-			ordered = append(ordered, pathAge{index: "build-log", path: path, age: info.ModTime()})
-		case "junit.failures":
-			stats.Entries++
-			stats.Size += info.Size()
-			ordered = append(ordered, pathAge{index: "junit", path: path, age: info.ModTime()})
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	sort.Slice(ordered, func(i, j int) bool { return ordered[i].age.After(ordered[j].age) })
-	pathIndex := make(map[string]int, len(ordered))
-	for i, item := range ordered {
-		path := strings.TrimPrefix(item.path, index.base)
-		pathIndex[path] = i
-	}
-
-	index.lock.Lock()
-	defer index.lock.Unlock()
-	index.ordered = ordered
-	index.pathIndex = pathIndex
-	index.stats = stats
-
-	return nil
-}
-
-func (i *pathIndex) Stats() PathIndexStats {
-	i.lock.Lock()
-	defer i.lock.Unlock()
-	return i.stats
-}
-
-func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
-	var paths []pathAge
-	i.lock.Lock()
-	paths = i.ordered
-	i.lock.Unlock()
-
-	// search all if we haven't built an index yet
-	if len(paths) == 0 {
-		return append(initial, i.base)
-	}
-
-	// grow the map to the desired size up front
-	if len(paths) > len(initial) {
-		copied := make([]string, len(initial), len(initial)+len(paths))
-		copy(copied, initial)
-		initial = copied
-	}
-
-	all := len(index.SearchType) == 0 || index.SearchType == "all"
-
-	if index.MaxAge > 0 {
-		oldest := time.Now().Add(-index.MaxAge)
-		for _, path := range paths {
-			if path.age.Before(oldest) {
-				break
-			}
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
-		}
-	} else {
-		for _, path := range paths {
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
-		}
-	}
-	return initial
 }

--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -202,7 +201,6 @@ func renderWithContext(ctx context.Context, w http.ResponseWriter, index *Index,
 		if count == 5 || count%50 == 0 {
 			bw.Flush()
 		}
-		name = strings.Trim(name, "/")
 		if lastName == name {
 			fmt.Fprintf(bw, "\n&mdash;\n\n")
 		} else {
@@ -220,7 +218,7 @@ func renderWithContext(ctx context.Context, w http.ResponseWriter, index *Index,
 			}
 
 			fmt.Fprintf(bw, `<div class="mb-4">`)
-			parts := bytes.SplitN([]byte(name), []byte{filepath.Separator}, 8)
+			parts := bytes.SplitN([]byte(name), []byte("/"), 8)
 			last := len(parts) - 1
 			switch {
 			case last > 2 && (bytes.Equal(parts[last], []byte("junit.failures")) || bytes.Equal(parts[last], []byte("build-log.txt"))):
@@ -287,7 +285,6 @@ func renderSummary(ctx context.Context, w http.ResponseWriter, index *Index, gen
 		if count == 5 || count%50 == 0 {
 			bw.Flush()
 		}
-		name = strings.Trim(name, "/")
 		if lastName == name {
 			// continue accumulating matches
 		} else {
@@ -308,7 +305,7 @@ func renderSummary(ctx context.Context, w http.ResponseWriter, index *Index, gen
 			}
 
 			fmt.Fprintf(bw, `<tr>`)
-			parts := bytes.SplitN([]byte(name), []byte{filepath.Separator}, 8)
+			parts := bytes.SplitN([]byte(name), []byte("/"), 8)
 			last := len(parts) - 1
 			switch {
 			case last > 2 && (bytes.Equal(parts[last], []byte("junit.failures")) || bytes.Equal(parts[last], []byte("build-log.txt"))):

--- a/cmd/search/job.go
+++ b/cmd/search/job.go
@@ -22,16 +22,16 @@ type ProwJob struct {
 	BuildID  string `json:"build_id"`
 }
 
-func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL) error {
+func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL, jobURIPrefix *url.URL) error {
 	date, err := time.Parse(time.RFC3339, job.Finished)
 	if err != nil {
 		return fmt.Errorf("prow job %s #%s had invalid date: %s", job.Job, job.BuildID, err)
 	}
 	logPath := job.URL
-	if !strings.HasPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/") {
+	if !strings.HasPrefix(logPath, jobURIPrefix.String()) {
 		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
 	}
-	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
+	logPath = path.Join(strings.TrimPrefix(logPath, jobURIPrefix.String()), "build-log.txt")
 	if _, ok := indexedPaths.MetadataFor(logPath); ok {
 		return nil
 	}

--- a/cmd/search/job.go
+++ b/cmd/search/job.go
@@ -32,7 +32,7 @@ func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir 
 		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
 	}
 	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
-	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
+	if _, ok := indexedPaths.MetadataFor(logPath); ok {
 		return nil
 	}
 
@@ -55,7 +55,7 @@ func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir 
 		}
 		return fmt.Errorf("unable to query prow job logs %s: %d %s", logsURL.String(), resp.StatusCode, resp.Status)
 	}
-	pathOnDisk := filepath.Join(append([]string{toDir}, strings.Split(logPath, "/")...)...)
+	pathOnDisk := filepath.Join(toDir, filepath.FromSlash(logPath))
 	parent := filepath.Dir(pathOnDisk)
 	if err := os.MkdirAll(parent, 0777); err != nil {
 		return fmt.Errorf("unable to create directory for prow job index: %v", err)

--- a/cmd/search/job.go
+++ b/cmd/search/job.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type ProwJob struct {
+	Type     string `json:"type"`
+	State    string `json:"state"`
+	URL      string `json:"url"`
+	Finished string `json:"finished"`
+	Job      string `json:"job"`
+	BuildID  string `json:"build_id"`
+}
+
+func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL) error {
+	date, err := time.Parse(time.RFC3339, job.Finished)
+	if err != nil {
+		return fmt.Errorf("prow job %s #%s had invalid date: %s", job.Job, job.BuildID, err)
+	}
+	logPath := job.URL
+	if !strings.HasPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/") {
+		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
+	}
+	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
+	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
+		return nil
+	}
+
+	logsURL := *deckURL
+	logsURL.Path = "/log"
+	query := url.Values{"id": []string{job.BuildID}, "job": []string{job.Job}}
+	logsURL.RawQuery = query.Encode()
+	resp, err := client.Get(logsURL.String())
+	if err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck: %v", err)
+	}
+	defer func() {
+		// ensure we pull the body completely so connections are reused
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode == 404 {
+			return nil
+		}
+		return fmt.Errorf("unable to query prow job logs %s: %d %s", logsURL.String(), resp.StatusCode, resp.Status)
+	}
+	pathOnDisk := filepath.Join(append([]string{toDir}, strings.Split(logPath, "/")...)...)
+	parent := filepath.Dir(pathOnDisk)
+	if err := os.MkdirAll(parent, 0777); err != nil {
+		return fmt.Errorf("unable to create directory for prow job index: %v", err)
+	}
+	f, err := os.OpenFile(pathOnDisk, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck, could not create log file: %v", err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck, could not copy log file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck, could not close log file: %v", err)
+	}
+	if err := os.Chtimes(pathOnDisk, date, date); err != nil {
+		return fmt.Errorf("unable to set file time while indexing to disk: %v", err)
+	}
+	return nil
+}

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -4,14 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -259,68 +257,4 @@ func (o *options) Run() error {
 	}
 
 	select {}
-}
-
-type ProwJob struct {
-	Type     string `json:"type"`
-	State    string `json:"state"`
-	URL      string `json:"url"`
-	Finished string `json:"finished"`
-	Job      string `json:"job"`
-	BuildID  string `json:"build_id"`
-}
-
-func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL) error {
-	date, err := time.Parse(time.RFC3339, job.Finished)
-	if err != nil {
-		return fmt.Errorf("prow job %s #%s had invalid date: %s", job.Job, job.BuildID, err)
-	}
-	logPath := job.URL
-	if !strings.HasPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/") {
-		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
-	}
-	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
-	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
-		return nil
-	}
-
-	logsURL := *deckURL
-	logsURL.Path = "/log"
-	query := url.Values{"id": []string{job.BuildID}, "job": []string{job.Job}}
-	logsURL.RawQuery = query.Encode()
-	resp, err := client.Get(logsURL.String())
-	if err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck: %v", err)
-	}
-	defer func() {
-		// ensure we pull the body completely so connections are reused
-		io.Copy(ioutil.Discard, resp.Body)
-		resp.Body.Close()
-	}()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if resp.StatusCode == 404 {
-			return nil
-		}
-		return fmt.Errorf("unable to query prow job logs %s: %d %s", logsURL.String(), resp.StatusCode, resp.Status)
-	}
-	pathOnDisk := filepath.Join(append([]string{toDir}, strings.Split(logPath, "/")...)...)
-	parent := filepath.Dir(pathOnDisk)
-	if err := os.MkdirAll(parent, 0777); err != nil {
-		return fmt.Errorf("unable to create directory for prow job index: %v", err)
-	}
-	f, err := os.OpenFile(pathOnDisk, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck, could not create log file: %v", err)
-	}
-	defer f.Close()
-	if _, err := io.Copy(f, resp.Body); err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck, could not copy log file: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck, could not close log file: %v", err)
-	}
-	if err := os.Chtimes(pathOnDisk, date, date); err != nil {
-		return fmt.Errorf("unable to set file time while indexing to disk: %v", err)
-	}
-	return nil
 }

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -32,6 +32,7 @@ func main() {
 		ListenAddr:   ":8080",
 		MaxAge:       14 * 24 * time.Hour,
 		JobURIPrefix: "https://openshift-gce-devel.appspot.com/build/",
+		DeckURI:      "https://prow.svc.ci.openshift.org",
 	}
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, arguments []string) {

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+type PathAccessor interface {
+	SearchPaths(*Index, []string) []string
+	Stats() PathIndexStats
+}
+
+type PathIndexStats struct {
+	Entries int
+	Size    int64
+}
+
+type Result struct {
+	FailedAt time.Time
+}
+
+type ResultMetadata interface {
+	MetadataFor(path string) (Result, bool)
+}
+
+type pathIndex struct {
+	base   string
+	maxAge time.Duration
+
+	lock      sync.Mutex
+	ordered   []pathAge
+	stats     PathIndexStats
+	pathIndex map[string]int
+}
+
+type pathAge struct {
+	path  string
+	index string
+	age   time.Time
+}
+
+func (index *pathIndex) MetadataFor(path string) (Result, bool) {
+	var age time.Time
+	var ok bool
+	index.lock.Lock()
+	position, ok := index.pathIndex[path]
+	if ok {
+		age = index.ordered[position].age
+	}
+	index.lock.Unlock()
+	if !ok {
+		return Result{}, false
+	}
+	return Result{FailedAt: age}, true
+}
+
+func (index *pathIndex) Load() error {
+	ordered := make([]pathAge, 0, 1024)
+
+	var err error
+	start := time.Now()
+	defer func() {
+		glog.Infof("Refreshed path index in %s, loaded %d: %v", time.Now().Sub(start).Truncate(time.Millisecond), len(ordered), err)
+	}()
+
+	mustExpire := index.maxAge != 0
+	expiredAt := start.Add(-index.maxAge)
+
+	stats := PathIndexStats{}
+
+	err = filepath.Walk(index.base, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if mustExpire && expiredAt.After(info.ModTime()) {
+			os.RemoveAll(path)
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		switch info.Name() {
+		case "build-log.txt":
+			stats.Entries++
+			stats.Size += info.Size()
+			ordered = append(ordered, pathAge{index: "build-log", path: path, age: info.ModTime()})
+		case "junit.failures":
+			stats.Entries++
+			stats.Size += info.Size()
+			ordered = append(ordered, pathAge{index: "junit", path: path, age: info.ModTime()})
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].age.After(ordered[j].age) })
+	pathIndex := make(map[string]int, len(ordered))
+	for i, item := range ordered {
+		path := strings.TrimPrefix(item.path, index.base)
+		pathIndex[path] = i
+	}
+
+	index.lock.Lock()
+	defer index.lock.Unlock()
+	index.ordered = ordered
+	index.pathIndex = pathIndex
+	index.stats = stats
+
+	return nil
+}
+
+func (i *pathIndex) Stats() PathIndexStats {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return i.stats
+}
+
+func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
+	var paths []pathAge
+	i.lock.Lock()
+	paths = i.ordered
+	i.lock.Unlock()
+
+	// search all if we haven't built an index yet
+	if len(paths) == 0 {
+		return append(initial, i.base)
+	}
+
+	// grow the map to the desired size up front
+	if len(paths) > len(initial) {
+		copied := make([]string, len(initial), len(initial)+len(paths))
+		copy(copied, initial)
+		initial = copied
+	}
+
+	all := len(index.SearchType) == 0 || index.SearchType == "all"
+
+	if index.MaxAge > 0 {
+		oldest := time.Now().Add(-index.MaxAge)
+		for _, path := range paths {
+			if path.age.Before(oldest) {
+				break
+			}
+			if all || path.index == index.SearchType {
+				initial = append(initial, path.path)
+			}
+		}
+	} else {
+		for _, path := range paths {
+			if all || path.index == index.SearchType {
+				initial = append(initial, path.path)
+			}
+		}
+	}
+	return initial
+}

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -146,21 +146,17 @@ func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
 
 	all := len(index.SearchType) == 0 || index.SearchType == "all"
 
+	var oldest time.Time
 	if index.MaxAge > 0 {
-		oldest := time.Now().Add(-index.MaxAge)
-		for _, path := range paths {
-			if path.age.Before(oldest) {
-				break
-			}
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
+		oldest = time.Now().Add(-index.MaxAge)
+	}
+
+	for _, path := range paths {
+		if path.age.Before(oldest) {
+			break
 		}
-	} else {
-		for _, path := range paths {
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
+		if all || path.index == index.SearchType {
+			initial = append(initial, path.path)
 		}
 	}
 	return initial


### PR DESCRIPTION
... and pass it around, instead of hard-coding the prefix in a number of locations.  As part of consuming the prefix URI, extend `MetadataFor` to handle the path decoding and job-URI construction as well, which
allows us to centralize some code that was previously duplicated between `renderWithContext` and `renderSummary`.

As part of this change, I've adjusted the output format a bit.  Most obviously by removing `template.HTMLEscapeString(string(parts[3])` from some `renderWithContext output`.  For example, master produced entries like:

```
build-log.txt from PR 22369 pull-ci-openshift-origin-master-e2e-aws-serial #5405 About an hour
build-log.txt from PR openshift_installer pull-ci-openshift-installer-master-e2e-openstack #189 4 hours
build-log.txt from build release-openshift-origin-installer-e2e-aws-upgrade #859 3 hours
```

With this commit, we get entries like:

```
build-log from pull pull-ci-openshift-origin-master-e2e-aws #7812 {duration}
build-log from pull pull-ci-openshift-installer-master-e2e-aws #5542 {duration}
build-log from build release-openshift-origin-installer-e2e-aws-4.0 #7077 {duration}
```

The PR number is nice, but when the PR number is instead a repository slug, it's redundant with the job name.  In fact, the trigger string is also fairly redundant with the job name (e.g. `...from pull pull-ci-...`, but I'm leaving that alone for now because at least we consistently detect it (vs. flip-flopping between PR number and repo slugs).

I don't have durations above, because when I copied down some example data from the `ci-search` pod, I didn't get whatever holds the finished-at times.  Or I broke duration calculation somehow with this commit ;).