### PR TITLE
cmd/search/main: Trim leading slash from MetadataFor argument

### DIFF
--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -280,7 +280,7 @@ func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir 
 		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
 	}
 	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
-	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
+	if _, ok := indexedPaths.MetadataFor(logPath); ok {
 		return nil
 	}
 


### PR DESCRIPTION
The leading slash was from 0b04030eaf (#13), but the other `MetadataFor` calls in that commit `Trim`ed slashes.