### PR TITLE
cmd/search/grep: Preserve 'initial' arguments for pre-index SearchPaths

### DIFF
--- a/cmd/search/grep.go
+++ b/cmd/search/grep.go
@@ -355,7 +355,7 @@ func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
 
 	// search all if we haven't built an index yet
 	if len(paths) == 0 {
-		return []string{i.base}
+		return append(initial, i.base)
 	}
 
 	// grow the map to the desired size up front


### PR DESCRIPTION
Fixing a bug from 9371ef7404 (#6), which ignored the initial arguments in the pre-index case.

CC @smarterclayton