### PR TITLE
cmd/search: Fix path vs. filepath separation and slash prefixes

### DIFF
--- a/cmd/search/grep.go
+++ b/cmd/search/grep.go
@@ -7,13 +7,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"sort"
 	"strconv"
-	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -28,22 +23,9 @@ type Index struct {
 	MaxAge time.Duration
 }
 
-type Result struct {
-	FailedAt time.Time
-}
-
-type ResultMetadata interface {
-	MetadataFor(path string) (Result, bool)
-}
-
 type CommandGenerator interface {
 	Command(*Index) (cmd string, args []string)
 	PathPrefix() string
-}
-
-type PathAccessor interface {
-	SearchPaths(*Index, []string) []string
-	Stats() PathIndexStats
 }
 
 type ripgrepGenerator struct {
@@ -243,146 +225,4 @@ func executeGrep(ctx context.Context, gen CommandGenerator, index *Index, maxLin
 			}
 		}
 	}
-}
-
-type pathIndex struct {
-	base   string
-	maxAge time.Duration
-
-	lock      sync.Mutex
-	ordered   []pathAge
-	stats     PathIndexStats
-	pathIndex map[string]int
-}
-
-type PathIndexStats struct {
-	Entries int
-	Size    int64
-}
-
-type pathAge struct {
-	path  string
-	index string
-	age   time.Time
-}
-
-func (index *pathIndex) MetadataFor(path string) (Result, bool) {
-	var age time.Time
-	var ok bool
-	index.lock.Lock()
-	position, ok := index.pathIndex[path]
-	if ok {
-		age = index.ordered[position].age
-	}
-	index.lock.Unlock()
-	if !ok {
-		return Result{}, false
-	}
-	return Result{FailedAt: age}, true
-}
-
-func (index *pathIndex) Load() error {
-	ordered := make([]pathAge, 0, 1024)
-
-	var err error
-	start := time.Now()
-	defer func() {
-		glog.Infof("Refreshed path index in %s, loaded %d: %v", time.Now().Sub(start).Truncate(time.Millisecond), len(ordered), err)
-	}()
-
-	mustExpire := index.maxAge != 0
-	expiredAt := start.Add(-index.maxAge)
-
-	stats := PathIndexStats{}
-
-	err = filepath.Walk(index.base, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-		if mustExpire && expiredAt.After(info.ModTime()) {
-			os.RemoveAll(path)
-			return nil
-		}
-		if info.IsDir() {
-			return nil
-		}
-		switch info.Name() {
-		case "build-log.txt":
-			stats.Entries++
-			stats.Size += info.Size()
-			ordered = append(ordered, pathAge{index: "build-log", path: path, age: info.ModTime()})
-		case "junit.failures":
-			stats.Entries++
-			stats.Size += info.Size()
-			ordered = append(ordered, pathAge{index: "junit", path: path, age: info.ModTime()})
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	sort.Slice(ordered, func(i, j int) bool { return ordered[i].age.After(ordered[j].age) })
-	pathIndex := make(map[string]int, len(ordered))
-	for i, item := range ordered {
-		path := strings.TrimPrefix(item.path, index.base)
-		pathIndex[path] = i
-	}
-
-	index.lock.Lock()
-	defer index.lock.Unlock()
-	index.ordered = ordered
-	index.pathIndex = pathIndex
-	index.stats = stats
-
-	return nil
-}
-
-func (i *pathIndex) Stats() PathIndexStats {
-	i.lock.Lock()
-	defer i.lock.Unlock()
-	return i.stats
-}
-
-func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
-	var paths []pathAge
-	i.lock.Lock()
-	paths = i.ordered
-	i.lock.Unlock()
-
-	// search all if we haven't built an index yet
-	if len(paths) == 0 {
-		return append(initial, i.base)
-	}
-
-	// grow the map to the desired size up front
-	if len(paths) > len(initial) {
-		copied := make([]string, len(initial), len(initial)+len(paths))
-		copy(copied, initial)
-		initial = copied
-	}
-
-	all := len(index.SearchType) == 0 || index.SearchType == "all"
-
-	if index.MaxAge > 0 {
-		oldest := time.Now().Add(-index.MaxAge)
-		for _, path := range paths {
-			if path.age.Before(oldest) {
-				break
-			}
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
-		}
-	} else {
-		for _, path := range paths {
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
-		}
-	}
-	return initial
 }

--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -202,7 +201,6 @@ func renderWithContext(ctx context.Context, w http.ResponseWriter, index *Index,
 		if count == 5 || count%50 == 0 {
 			bw.Flush()
 		}
-		name = strings.Trim(name, "/")
 		if lastName == name {
 			fmt.Fprintf(bw, "\n&mdash;\n\n")
 		} else {
@@ -220,7 +218,7 @@ func renderWithContext(ctx context.Context, w http.ResponseWriter, index *Index,
 			}
 
 			fmt.Fprintf(bw, `<div class="mb-4">`)
-			parts := bytes.SplitN([]byte(name), []byte{filepath.Separator}, 8)
+			parts := bytes.SplitN([]byte(name), []byte("/"), 8)
 			last := len(parts) - 1
 			switch {
 			case last > 2 && (bytes.Equal(parts[last], []byte("junit.failures")) || bytes.Equal(parts[last], []byte("build-log.txt"))):
@@ -287,7 +285,6 @@ func renderSummary(ctx context.Context, w http.ResponseWriter, index *Index, gen
 		if count == 5 || count%50 == 0 {
 			bw.Flush()
 		}
-		name = strings.Trim(name, "/")
 		if lastName == name {
 			// continue accumulating matches
 		} else {
@@ -308,7 +305,7 @@ func renderSummary(ctx context.Context, w http.ResponseWriter, index *Index, gen
 			}
 
 			fmt.Fprintf(bw, `<tr>`)
-			parts := bytes.SplitN([]byte(name), []byte{filepath.Separator}, 8)
+			parts := bytes.SplitN([]byte(name), []byte("/"), 8)
 			last := len(parts) - 1
 			switch {
 			case last > 2 && (bytes.Equal(parts[last], []byte("junit.failures")) || bytes.Equal(parts[last], []byte("build-log.txt"))):

--- a/cmd/search/job.go
+++ b/cmd/search/job.go
@@ -32,7 +32,7 @@ func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir 
 		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
 	}
 	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
-	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
+	if _, ok := indexedPaths.MetadataFor(logPath); ok {
 		return nil
 	}
 
@@ -55,7 +55,7 @@ func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir 
 		}
 		return fmt.Errorf("unable to query prow job logs %s: %d %s", logsURL.String(), resp.StatusCode, resp.Status)
 	}
-	pathOnDisk := filepath.Join(append([]string{toDir}, strings.Split(logPath, "/")...)...)
+	pathOnDisk := filepath.Join(toDir, filepath.FromSlash(logPath))
 	parent := filepath.Dir(pathOnDisk)
 	if err := os.MkdirAll(parent, 0777); err != nil {
 		return fmt.Errorf("unable to create directory for prow job index: %v", err)

--- a/cmd/search/job.go
+++ b/cmd/search/job.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type ProwJob struct {
+	Type     string `json:"type"`
+	State    string `json:"state"`
+	URL      string `json:"url"`
+	Finished string `json:"finished"`
+	Job      string `json:"job"`
+	BuildID  string `json:"build_id"`
+}
+
+func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL) error {
+	date, err := time.Parse(time.RFC3339, job.Finished)
+	if err != nil {
+		return fmt.Errorf("prow job %s #%s had invalid date: %s", job.Job, job.BuildID, err)
+	}
+	logPath := job.URL
+	if !strings.HasPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/") {
+		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
+	}
+	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
+	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
+		return nil
+	}
+
+	logsURL := *deckURL
+	logsURL.Path = "/log"
+	query := url.Values{"id": []string{job.BuildID}, "job": []string{job.Job}}
+	logsURL.RawQuery = query.Encode()
+	resp, err := client.Get(logsURL.String())
+	if err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck: %v", err)
+	}
+	defer func() {
+		// ensure we pull the body completely so connections are reused
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode == 404 {
+			return nil
+		}
+		return fmt.Errorf("unable to query prow job logs %s: %d %s", logsURL.String(), resp.StatusCode, resp.Status)
+	}
+	pathOnDisk := filepath.Join(append([]string{toDir}, strings.Split(logPath, "/")...)...)
+	parent := filepath.Dir(pathOnDisk)
+	if err := os.MkdirAll(parent, 0777); err != nil {
+		return fmt.Errorf("unable to create directory for prow job index: %v", err)
+	}
+	f, err := os.OpenFile(pathOnDisk, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck, could not create log file: %v", err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck, could not copy log file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("unable to index prow jobs from Deck, could not close log file: %v", err)
+	}
+	if err := os.Chtimes(pathOnDisk, date, date); err != nil {
+		return fmt.Errorf("unable to set file time while indexing to disk: %v", err)
+	}
+	return nil
+}

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -4,14 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -259,68 +257,4 @@ func (o *options) Run() error {
 	}
 
 	select {}
-}
-
-type ProwJob struct {
-	Type     string `json:"type"`
-	State    string `json:"state"`
-	URL      string `json:"url"`
-	Finished string `json:"finished"`
-	Job      string `json:"job"`
-	BuildID  string `json:"build_id"`
-}
-
-func fetchJob(client *http.Client, job *ProwJob, indexedPaths *pathIndex, toDir string, deckURL *url.URL) error {
-	date, err := time.Parse(time.RFC3339, job.Finished)
-	if err != nil {
-		return fmt.Errorf("prow job %s #%s had invalid date: %s", job.Job, job.BuildID, err)
-	}
-	logPath := job.URL
-	if !strings.HasPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/") {
-		return fmt.Errorf("prow job %s %s had invalid URL: %s", job.Job, job.BuildID, logPath)
-	}
-	logPath = path.Join(strings.TrimPrefix(logPath, "https://openshift-gce-devel.appspot.com/build/"), "build-log.txt")
-	if _, ok := indexedPaths.MetadataFor("/" + logPath); ok {
-		return nil
-	}
-
-	logsURL := *deckURL
-	logsURL.Path = "/log"
-	query := url.Values{"id": []string{job.BuildID}, "job": []string{job.Job}}
-	logsURL.RawQuery = query.Encode()
-	resp, err := client.Get(logsURL.String())
-	if err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck: %v", err)
-	}
-	defer func() {
-		// ensure we pull the body completely so connections are reused
-		io.Copy(ioutil.Discard, resp.Body)
-		resp.Body.Close()
-	}()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if resp.StatusCode == 404 {
-			return nil
-		}
-		return fmt.Errorf("unable to query prow job logs %s: %d %s", logsURL.String(), resp.StatusCode, resp.Status)
-	}
-	pathOnDisk := filepath.Join(append([]string{toDir}, strings.Split(logPath, "/")...)...)
-	parent := filepath.Dir(pathOnDisk)
-	if err := os.MkdirAll(parent, 0777); err != nil {
-		return fmt.Errorf("unable to create directory for prow job index: %v", err)
-	}
-	f, err := os.OpenFile(pathOnDisk, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck, could not create log file: %v", err)
-	}
-	defer f.Close()
-	if _, err := io.Copy(f, resp.Body); err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck, could not copy log file: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("unable to index prow jobs from Deck, could not close log file: %v", err)
-	}
-	if err := os.Chtimes(pathOnDisk, date, date); err != nil {
-		return fmt.Errorf("unable to set file time while indexing to disk: %v", err)
-	}
-	return nil
 }

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+type PathAccessor interface {
+	SearchPaths(*Index, []string) []string
+	Stats() PathIndexStats
+}
+
+type PathIndexStats struct {
+	Entries int
+	Size    int64
+}
+
+type Result struct {
+	FailedAt time.Time
+}
+
+type ResultMetadata interface {
+	MetadataFor(path string) (Result, bool)
+}
+
+type pathIndex struct {
+	base   string
+	maxAge time.Duration
+
+	lock      sync.Mutex
+	ordered   []pathAge
+	stats     PathIndexStats
+	pathIndex map[string]int
+}
+
+type pathAge struct {
+	path  string
+	index string
+	age   time.Time
+}
+
+func (index *pathIndex) MetadataFor(path string) (Result, bool) {
+	var age time.Time
+	var ok bool
+	index.lock.Lock()
+	position, ok := index.pathIndex[path]
+	if ok {
+		age = index.ordered[position].age
+	}
+	index.lock.Unlock()
+	if !ok {
+		return Result{}, false
+	}
+	return Result{FailedAt: age}, true
+}
+
+func (index *pathIndex) Load() error {
+	ordered := make([]pathAge, 0, 1024)
+
+	var err error
+	start := time.Now()
+	defer func() {
+		glog.Infof("Refreshed path index in %s, loaded %d: %v", time.Now().Sub(start).Truncate(time.Millisecond), len(ordered), err)
+	}()
+
+	mustExpire := index.maxAge != 0
+	expiredAt := start.Add(-index.maxAge)
+
+	stats := PathIndexStats{}
+
+	err = filepath.Walk(index.base, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if mustExpire && expiredAt.After(info.ModTime()) {
+			os.RemoveAll(path)
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		switch info.Name() {
+		case "build-log.txt":
+			stats.Entries++
+			stats.Size += info.Size()
+			ordered = append(ordered, pathAge{index: "build-log", path: path, age: info.ModTime()})
+		case "junit.failures":
+			stats.Entries++
+			stats.Size += info.Size()
+			ordered = append(ordered, pathAge{index: "junit", path: path, age: info.ModTime()})
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].age.After(ordered[j].age) })
+	pathIndex := make(map[string]int, len(ordered))
+	for i, item := range ordered {
+		path := strings.TrimPrefix(item.path, index.base)
+		pathIndex[path] = i
+	}
+
+	index.lock.Lock()
+	defer index.lock.Unlock()
+	index.ordered = ordered
+	index.pathIndex = pathIndex
+	index.stats = stats
+
+	return nil
+}
+
+func (i *pathIndex) Stats() PathIndexStats {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return i.stats
+}
+
+func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
+	var paths []pathAge
+	i.lock.Lock()
+	paths = i.ordered
+	i.lock.Unlock()
+
+	// search all if we haven't built an index yet
+	if len(paths) == 0 {
+		return append(initial, i.base)
+	}
+
+	// grow the map to the desired size up front
+	if len(paths) > len(initial) {
+		copied := make([]string, len(initial), len(initial)+len(paths))
+		copy(copied, initial)
+		initial = copied
+	}
+
+	all := len(index.SearchType) == 0 || index.SearchType == "all"
+
+	if index.MaxAge > 0 {
+		oldest := time.Now().Add(-index.MaxAge)
+		for _, path := range paths {
+			if path.age.Before(oldest) {
+				break
+			}
+			if all || path.index == index.SearchType {
+				initial = append(initial, path.path)
+			}
+		}
+	} else {
+		for _, path := range paths {
+			if all || path.index == index.SearchType {
+				initial = append(initial, path.path)
+			}
+		}
+	}
+	return initial
+}

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -146,21 +146,17 @@ func (i *pathIndex) SearchPaths(index *Index, initial []string) []string {
 
 	all := len(index.SearchType) == 0 || index.SearchType == "all"
 
+	var oldest time.Time
 	if index.MaxAge > 0 {
-		oldest := time.Now().Add(-index.MaxAge)
-		for _, path := range paths {
-			if path.age.Before(oldest) {
-				break
-			}
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
+		oldest = time.Now().Add(-index.MaxAge)
+	}
+
+	for _, path := range paths {
+		if path.age.Before(oldest) {
+			break
 		}
-	} else {
-		for _, path := range paths {
-			if all || path.index == index.SearchType {
-				initial = append(initial, path.path)
-			}
+		if all || path.index == index.SearchType {
+			initial = append(initial, path.path)
 		}
 	}
 	return initial


### PR DESCRIPTION
Clear up some inconsistencies in the existing codebase by documenting:

* `SearchPaths` as returning a slice of filesystem paths, which is has done since it landed in 0ba41f4cff (#2).

* `MetadataFor` (and its backing `pathIndex.ordered`) as taking a slash-separated relative path.  This completes a transition started in 0b04030eaf (#13) of trimming leading slashes in some locations.

* `executeGrep`'s callback.  0b04030eaf began trimming leading slashes removed in the callbacks; this commit pushes that trim (and `ToSlash` casting) into `executeGrep` itself, so the callback can drop the name into `MetadataFor` without needing to modify it.

This also fixes `fetchJob` to drop its leading slash, which was broken since 0b04030eaf, leading to:

```
W0426 17:39:57.457197       1 main.go:177] Job index failed: unable to index prow jobs from Deck, could not create log file: open /var/lib/ci-search/origin-ci-test/logs/periodic-ci-azure-vmimage/3/build-log.txt: file exists
```

as we attempted to re-pull data after missing a cache lookup because our index used relative paths while `fetchJob`'s call still used slash-prefixed paths.

And it fixes `pathIndex.Load` to use relative paths instead of the raw paths returned by `Walk`.  For example, with:

```console
$ search --path data ...
```

`Walk` would return paths like:

```
data/origin-ci-test/pr-logs/pull/redhat-developer_devconsole-operator/144/pull-ci-redhat-developer-devconsole-operator-master-e2e/67/build-log.txt
```

With this commit, we no longer have the buggy `data/` prefix (which would not match log paths extracted from job URIs, etc.) and use:

```
origin-ci-test/pr-logs/pull/redhat-developer_devconsole-operator/144/pull-ci-redhat-developer-devconsole-operator-master-e2e/67/build-log.txt
```

While I was wrapping my head around how these pieces fit together, I made a few no-op refactors to shuffle some bits around.  They should be fairly easy to review, but let me know if they aren't, and I'll drop them from this pull request.