### PR TITLE
cmd/search/main: Set a default --deck-uri

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN curl -L https://github.com/BurntSushi/ripgrep/releases/download/0.10.0/ripgr
 RUN mkdir /var/lib/ci-search && chown 1000:1000 /var/lib/ci-search && chmod 1777 /var/lib/ci-search
 USER 1000:1000
 ENTRYPOINT ["search"]
-CMD ["--interval=5m", "--path=/var/lib/ci-search/", "--deck-uri=https://prow.svc.ci.openshift.org"]
+CMD ["--interval=5m", "--path=/var/lib/ci-search/"]
 EXPOSE 8080

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -33,6 +33,7 @@ func main() {
 		MaxAge:            14 * 24 * time.Hour,
 		JobURIPrefix:      "https://prow.svc.ci.openshift.org/view/gcs/",
 		ArtifactURIPrefix: "https://storage.googleapis.com/",
+		DeckURI:           "https://prow.svc.ci.openshift.org",
 	}
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, arguments []string) {


### PR DESCRIPTION
One less thing to think about when launching this against OpenStack's CI, and a useful example for folks who want to launch against some other Prow/Deck setup.

This had been part of #16, but I'd left it out of #24 by accident.

/assign @smarterclayton