### PR TITLE
cmd/search/chart: Only color matching failed jobs

### DIFF
--- a/cmd/search/chart.go
+++ b/cmd/search/chart.go
@@ -195,7 +195,7 @@ var htmlChart = template.Must(template.New("chart").Funcs(map[string]interface{}
         }
 
         var matches = regexpMatches(job);
-        if (matches.size > 0) {
+        if (matches.size > 0 && job.status.state == 'failure') {
           var matchedColor;
           [...regexps.keys()].some((regexp, i) => {
             if (matches.get(regexp)) {


### PR DESCRIPTION
The production CI-search deployment also indexes build logs and JUnit files for successful jobs.  That's useful for identifying noisy regular expressions, but the chart UI doesn't currently have a way to distinguish between "failed and matches" and "success and matches".  Until it grows a way, just color the failures and leave the successes gray.

/assign @smarterclayton