### PR TITLE
cmd/search/chartpng: Only color matching failed jobs

### DIFF
--- a/cmd/search/httpchartpng.go
+++ b/cmd/search/httpchartpng.go
@@ -84,12 +84,14 @@ func (o *options) handleChartPNG(w http.ResponseWriter, req *http.Request) {
 		}
 
 		i := -1
-		matches, ok := result[job.Status.URL]
-		if ok {
-			for j, search := range index.Search {
-				if _, ok := matches[search]; ok {
-					i = j
-					break
+		if job.Status.State == "failure" {
+			matches, ok := result[job.Status.URL]
+			if ok {
+				for j, search := range index.Search {
+					if _, ok := matches[search]; ok {
+						i = j
+						break
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Like 90b680eb31 (#26), but for the chart PNG (vs. the JavaScript SVG).

/assign @smarterclayton