### PR TITLE
cmd/search/jobs: "Info" -> "Infof" for loaded lines

### DIFF
--- a/cmd/search/jobs.go
+++ b/cmd/search/jobs.go
@@ -47,9 +47,9 @@ func getJobs() ([]ProwJob, error) {
 	var jobs ProwJobs
 	err := json.Unmarshal(jobBytes, &jobs)
 	if err == nil {
-		glog.Info("Loaded %d prow jobs", len(jobs.Items))
+		glog.Infof("Loaded %d prow jobs", len(jobs.Items))
 	} else {
-		glog.Info("Failed to load prow jobs: %v", err)
+		glog.Infof("Failed to load prow jobs: %v", err)
 	}
 	return jobs.Items, err
 }


### PR DESCRIPTION
Avoid:

```
I0113 21:57:50.243007       1 jobs.go:50] Loaded %d prow jobs4074
```

and similar, fixing a typo from a369cbd2bf (#24).