### PR TITLE
perf: Use include_fields to strip down bugzilla response, use paging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.11
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
 WORKDIR /go/src/github.com/openshift/ci-search
 COPY . .
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 build:
-	go build ./testgrid/cmd/build-indexer
-	go build ./cmd/search
+	go build -mod vendor ./testgrid/cmd/build-indexer
+	go build -mod vendor ./cmd/search
 .PHONY: build

--- a/bugzilla/client.go
+++ b/bugzilla/client.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
 
 	"k8s.io/klog"
 )
@@ -67,6 +68,7 @@ func (c *Client) BugCommentsByID(ctx context.Context, bugs ...int) (*BugComments
 	for _, bug := range bugs[1:] {
 		v.Add("ids", strconv.Itoa(bug))
 	}
+	v.Add("include_fields", strings.Join(bugCommentFields, ","))
 	u.RawQuery = v.Encode()
 
 	var bugList *BugCommentsList
@@ -82,6 +84,9 @@ func (c *Client) BugCommentsByID(ctx context.Context, bugs ...int) (*BugComments
 func (c *Client) SearchBugs(ctx context.Context, args SearchBugsArgs) (*BugInfoList, error) {
 	u := c.Base
 	u.Path = path.Join(u.Path, "bug")
+	if args.IncludeFields == nil {
+		args.IncludeFields = bugInfoFields
+	}
 	v := c.newRequestValues()
 	args.Add(v)
 	u.RawQuery = v.Encode()

--- a/bugzilla/comments_test.go
+++ b/bugzilla/comments_test.go
@@ -38,7 +38,7 @@ func TestCommentStore(t *testing.T) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	defer cancelFn()
 
-	informer := NewInformer(c, 30*time.Second, 1*time.Minute, func(metav1.ListOptions) SearchBugsArgs {
+	informer := NewInformer(c, 30*time.Second, 0, 1*time.Minute, func(metav1.ListOptions) SearchBugsArgs {
 		return SearchBugsArgs{
 			Quicksearch: "cf_internal_whiteboard:buildcop",
 		}

--- a/bugzilla/informer_test.go
+++ b/bugzilla/informer_test.go
@@ -74,7 +74,7 @@ func TestInformer(t *testing.T) {
 	}
 	c.Client = &http.Client{Transport: rt}
 
-	informer := NewInformer(c, 30*time.Second, 1*time.Minute, func(metav1.ListOptions) SearchBugsArgs {
+	informer := NewInformer(c, 30*time.Second, 0, 1*time.Minute, func(metav1.ListOptions) SearchBugsArgs {
 		return SearchBugsArgs{
 			Quicksearch: "cf_internal_whiteboard:buildcop",
 		}

--- a/bugzilla/types.go
+++ b/bugzilla/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,6 +83,8 @@ type BugComment struct {
 	Text         string      `json:"text"`
 }
 
+var bugCommentFields = []string{"id", "is_private", "creator", "creation_time", "time", "text"}
+
 type BugInfo struct {
 	ID                 int         `json:"id"`
 	Status             string      `json:"status"`
@@ -98,10 +101,16 @@ type BugInfo struct {
 	LastChangeTime     metav1.Time `json:"last_change_time"`
 }
 
+var bugInfoFields = []string{"id", "status", "resolution", "severity", "priority", "summary", "keywords", "whiteboard", "cf_internal_whiteboard", "creator", "assigned_to", "creation_time", "last_change_time"}
+
 type SearchBugsArgs struct {
 	LastChangeTime time.Time
 	IDs            []int
 	Quicksearch    string
+
+	IncludeFields []string
+	Limit         int
+	Offset        int
 }
 
 func (arg SearchBugsArgs) Add(v url.Values) {
@@ -113,6 +122,15 @@ func (arg SearchBugsArgs) Add(v url.Values) {
 	}
 	if len(arg.Quicksearch) > 0 {
 		v.Set("quicksearch", arg.Quicksearch)
+	}
+	if len(arg.IncludeFields) > 0 {
+		v.Set("include_fields", strings.Join(arg.IncludeFields, ","))
+	}
+	if arg.Limit > 0 {
+		v.Set("limit", strconv.Itoa(arg.Limit))
+	}
+	if arg.Offset > 0 || arg.Limit > 0 {
+		v.Set("offset", strconv.Itoa(arg.Offset))
 	}
 }
 

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -280,7 +280,10 @@ func (o *options) Run() error {
 		}
 		c.Client = &http.Client{Transport: rt}
 		informer := bugzilla.NewInformer(
-			c, 10*time.Minute, 30*time.Minute,
+			c,
+			10*time.Minute,
+			8*time.Hour,
+			30*time.Minute,
 			func(metav1.ListOptions) bugzilla.SearchBugsArgs {
 				return bugzilla.SearchBugsArgs{
 					Quicksearch: o.BugzillaSearch,


### PR DESCRIPTION
Reduces query time from 2m or more to a more manageable 10-30s

Also standardize on the table viewer and remove the logic that purges
bugs on disk on startup.