### PR TITLE
When a line is longer than the buffer size, correctly consume it

### DIFF
--- a/cmd/search/grep_test.go
+++ b/cmd/search/grep_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"k8s.io/klog"
+)
+
+func init() {
+	klog.InitFlags(flag.CommandLine)
+}
+
+type fakeCommand struct {
+	prefix  string
+	command string
+	args    []string
+	err     error
+}
+
+func (f *fakeCommand) Command(index *Index, search string) (cmd string, args []string, err error) {
+	return f.command, f.args, f.err
+}
+func (f *fakeCommand) PathPrefix() string {
+	return f.prefix
+}
+
+func Test_executeGrepSingle(t *testing.T) {
+	// cat, err := exec.LookPath("cat")
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+	// cmd := &fakeCommand{prefix: "/var/lib/ci-search", command: cat, args: []string{"-e", "/tmp/logs"}}
+	// fn := func(name string, search string, lines []bytes.Buffer, moreLines int) {
+	// 	t.Logf("%s %d", name, len(lines))
+	// }
+	// if err := executeGrepSingle(context.TODO(), cmd, &Index{}, "etcdserver", 30, fn); err != io.EOF {
+	// 	t.Fatal(err)
+	// }
+}


### PR DESCRIPTION
The isPrefix loop was subtly wrong - if we had a very long line
followed by a very short line (one where isPrefix was false) we'd
end up in the wrong position. Always consume the line when we're in
a prefix.