### PR TITLE
cmd/search/types: Mention 'type' in invalid-type error message

### DIFF
--- a/cmd/search/types.go
+++ b/cmd/search/types.go
@@ -125,7 +125,7 @@ func parseRequest(req *http.Request, mode string, maxAge time.Duration) (*Index,
 	case "all":
 		index.SearchType = "all"
 	default:
-		return nil, fmt.Errorf("search must be 'bug', 'junit', 'build-log', or 'all'")
+		return nil, fmt.Errorf("search type must be 'bug', 'junit', 'build-log', or 'all'")
 	}
 
 	if value := req.FormValue("name"); len(value) > 0 || mode == "chart" {


### PR DESCRIPTION
Improving on:

```console
$ curl -s 'https://search.svc.ci.openshift.org/search?type=does-not-exist'
Bad input: search must be 'bug', 'junit', 'build-log', or 'all'
```