### PR TITLE
cmd/search/httpchart: Fix chart search type

### DIFF
--- a/cmd/search/httpchart.go
+++ b/cmd/search/httpchart.go
@@ -157,6 +157,7 @@ var htmlChart = template.Must(template.New("chart").Funcs(map[string]interface{}
 
       var filter = '{{.index.Job}}';
       var dateRange = {{.index.MaxAge.Seconds}};  // in seconds
+      var searchType = '{{.index.SearchType}}';
 
       // {
       //   "regexp-pattern": {
@@ -461,6 +462,7 @@ var htmlChart = template.Must(template.New("chart").Funcs(map[string]interface{}
         searchParams.append('name', filter);
         searchParams.append('maxAge', dateRange + 's');  // chart is by start, but maxAge is by finish, so no need to expand this to handle drifting relative times.
         searchParams.append('context', 0);
+        searchParams.append('type', searchType);
         regexps.forEach((_, regexp) => {
           searchParams.append('search', regexp);
         });

--- a/cmd/search/types.go
+++ b/cmd/search/types.go
@@ -114,7 +114,13 @@ func parseRequest(req *http.Request, mode string, maxAge time.Duration) (*Index,
 	}
 
 	switch req.FormValue("type") {
-	case "bug+junit", "":
+	case "":
+		if mode == "chart" {
+			index.SearchType = "all"
+		} else {
+			index.SearchType = "bug+junit"
+		}
+	case "bug+junit":
 		index.SearchType = "bug+junit"
 	case "bug":
 		index.SearchType = "bug"


### PR DESCRIPTION
2d8841e549 (#30) pivoted the default type from 'all' to 'bug+junit', excluding 'build-log'.  But the chart regular expressions mostly target the build-log.  Flip the default chart type back to 'all' (although we don't really care about 'bug'; 'build-log+junit' would be fine if it existed).  And set up the HTTP chart handler to pass through type query parameters, so they can do:

   https://search.svc.ci.openshift.org/chart?type=junit&search=whatever

if they want a more focused search.