### PR TITLE
Add debugging to help identify cause of misaligned grep

### DIFF
--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -29,7 +29,6 @@ type Match struct {
 }
 
 func (o *options) handleConfig(w http.ResponseWriter, req *http.Request) {
-	o.ConfigPath = "README.md"
 	if o.ConfigPath == "" {
 		w.WriteHeader(http.StatusNoContent)
 		return


### PR DESCRIPTION
Occasionally we fail to get a result because the filename lacks a
leading slash. Add error debugging around filename parsing to see
if we can narrow down the range.

Should help debug #41 