### PR TITLE
Search results older than 15m

### DIFF
--- a/cmd/search/jobs.go
+++ b/cmd/search/jobs.go
@@ -18,23 +18,7 @@ var jobBytes []byte
 type Job prow.Job
 
 func (job *Job) StartStop() (time.Time, time.Time, error) {
-	return time.Time{}, time.Time{}, nil
-	// var zero time.Time
-
-	// started, err := time.Parse(time.RFC3339, job.Status.StartTime)
-	// if err != nil {
-	// 	return zero, zero, fmt.Errorf("prow job %s #%s had invalid 'startTime': %s", job.Spec.Job, job.Status.BuildID, err)
-	// }
-
-	// var finished time.Time
-	// if job.Status.CompletionTime != "" {
-	// 	finished, err = time.Parse(time.RFC3339, job.Status.CompletionTime)
-	// 	if err != nil {
-	// 		return zero, zero, fmt.Errorf("prow job %s #%s had invalid 'completionTime': %s", job.Spec.Job, job.Status.BuildID, err)
-	// 	}
-	// }
-
-	// return started, finished, nil
+	return job.Status.StartTime.Time, job.Status.CompletionTime.Time, nil
 }
 
 func (o *options) handleJobs(w http.ResponseWriter, req *http.Request) {

--- a/prow/index.go
+++ b/prow/index.go
@@ -68,6 +68,13 @@ func (s *DiskStore) Run(ctx context.Context, informer cache.SharedIndexInformer,
 				}
 				s.notifyChanged(fmt.Sprintf("%s/%s", job.Namespace, job.Name))
 			},
+			UpdateFunc: func(_, obj interface{}) {
+				job, ok := obj.(*Job)
+				if !ok {
+					return
+				}
+				s.notifyChanged(fmt.Sprintf("%s/%s", job.Namespace, job.Name))
+			},
 		},
 	})
 


### PR DESCRIPTION
We should use maxAge as the gate, was accidentally set to a constant.
Increase parallelism and expose an optional debug port. Mark dead flags
as out of date.