### PR TITLE
cmd/search/types: Drop the 24h maxAge for the chart

### DIFF
--- a/cmd/search/types.go
+++ b/cmd/search/types.go
@@ -154,17 +154,11 @@ func parseRequest(req *http.Request, mode string, maxAge time.Duration) (*Index,
 		}
 		index.MaxAge = maxAge
 	}
-	if mode == "chart" {
-		if index.MaxAge == 0 || index.MaxAge > 24*time.Hour {
-			index.MaxAge = 24 * time.Hour
-		}
-	} else {
-		if index.MaxAge == 0 {
-			index.MaxAge = 2 * 24 * time.Hour
-		}
-		if index.MaxAge > maxAge {
-			index.MaxAge = maxAge
-		}
+	if index.MaxAge == 0 {
+		index.MaxAge = 2 * 24 * time.Hour
+	}
+	if index.MaxAge > maxAge {
+		index.MaxAge = maxAge
 	}
 
 	if context := req.FormValue("context"); len(context) > 0 {


### PR DESCRIPTION
Not sure when this changed, but we now have ProwJob data that's much deeper:

```console
$ curl -s https://search.svc.ci.openshift.org/jobs | jq -r '[.items[].status.startTime | select(. != null)] | sort | .[0]'
2020-01-01T00:00:06Z
$ curl -s https://prow.svc.ci.openshift.org/prowjobs.js | jq -r '[.items[].status.startTime | select(. != null)] | sort | .[0]'
2020-01-01T00:00:06Z
```

so drop the stale 24h cap.