### PR TITLE
cmd/search/httpchartpng: Restore job-name filtering

### DIFF
--- a/cmd/search/httpchartpng.go
+++ b/cmd/search/httpchartpng.go
@@ -75,6 +75,10 @@ func (o *options) handleChartPNG(w http.ResponseWriter, req *http.Request) {
 	maxDuration := 0
 	scatters := make([]*scatter, len(index.Search)+4)
 	for _, job := range jobs {
+		if index.Job != nil && !index.Job.MatchString(job.Spec.Job) {
+			continue
+		}
+
 		start, stop := job.Status.StartTime.Time, job.Status.CompletionTime.Time
 		if start.Before(minTime) {
 			continue


### PR DESCRIPTION
It was dropped in 2d8841e549 (Add "bugs" as a source, 2020-03-16, #30).

Fixes #42.