### PR TITLE
cmd/search/httpchart: Draw errors in black

### DIFF
--- a/cmd/search/httpchart.go
+++ b/cmd/search/httpchart.go
@@ -17,7 +17,6 @@ var colors = []color.Color{
 	color.RGBA{0xe6, 0xbe, 0xff, 0xff}, // lavender
 	color.RGBA{0x00, 0x00, 0x75, 0xff}, // navy
 	color.RGBA{0x43, 0x63, 0xd8, 0xff}, // blue
-	color.RGBA{0x00, 0x00, 0x00, 0xff}, // black
 	color.RGBA{0xe6, 0x19, 0x4B, 0xff}, // red
 	color.RGBA{0x42, 0xd4, 0xf4, 0xff}, // cyan
 	color.RGBA{0xf0, 0x32, 0xe6, 0xff}, // magenta
@@ -30,6 +29,7 @@ var colors = []color.Color{
 }
 
 var specialColors = map[string]color.Color{
+	"error":   color.RGBA{0x00, 0x00, 0x00, 0xff}, // black
 	"failure": color.RGBA{0xf5, 0x82, 0x31, 0xff}, // orange
 	"pending": color.RGBA{0xff, 0xe1, 0x19, 0xff}, // yellow
 	"success": color.RGBA{0xa9, 0xa9, 0xa9, 0xff}, // gray
@@ -217,6 +217,8 @@ var htmlChart = template.Must(template.New("chart").Funcs(map[string]interface{}
           return;
         case 'success':
           return '{{hexColor .specialColors.success}}';
+        case 'error':
+          return '{{hexColor .specialColors.error}}';
         case 'failure':
           return '{{hexColor .specialColors.failure}}';
         case 'pending':
@@ -381,7 +383,7 @@ var htmlChart = template.Must(template.New("chart").Funcs(map[string]interface{}
           color: color({status: {state: 'failure'}}),
           text: matchCount + ' (' + Math.round(matchCount / (totalFailures || 1) * 100) + '% of all failures) other failures',
         });
-        ['pending', 'success'].forEach(state => {
+        ['error', 'pending', 'success'].forEach(state => {
           matchCount = data.filter(job => job.status.state === state).length;
           legend.push({
             color: color({status: {state: state}}),

--- a/cmd/search/httpchartpng.go
+++ b/cmd/search/httpchartpng.go
@@ -73,7 +73,7 @@ func (o *options) handleChartPNG(w http.ResponseWriter, req *http.Request) {
 	}
 
 	maxDuration := 0
-	scatters := make([]*scatter, len(index.Search)+3)
+	scatters := make([]*scatter, len(index.Search)+4)
 	for _, job := range jobs {
 		start, stop := job.Status.StartTime.Time, job.Status.CompletionTime.Time
 		if start.Before(minTime) {
@@ -94,6 +94,8 @@ func (o *options) handleChartPNG(w http.ResponseWriter, req *http.Request) {
 		}
 		if i < 0 {
 			switch job.Status.State {
+			case "error":
+				i = len(scatters) - 4
 			case "failure":
 				i = len(scatters) - 3
 			case "pending":
@@ -156,6 +158,8 @@ func (o *options) handleChartPNG(w http.ResponseWriter, req *http.Request) {
 			clr = specialColors["pending"]
 		case 3:
 			clr = specialColors["failure"]
+		case 4:
+			clr = specialColors["error"]
 		default:
 			if i < len(colors) {
 				clr = colors[i]


### PR DESCRIPTION
Fix chart console logs like:

```
unrecognized job state error
```

from jobs like:

```console
$ curl -s https://prow.svc.ci.openshift.org/prowjobs.js | jq -r '[.items[] | select(.status.state == "error")][0]'
{
  ...
  "spec": {
    ...
    "job": "rehearse-8023-pull-ci-openshift-cluster-image-registry-operator-master-e2e-vsphere",
    ...
  },
  "status": {
    "startTime": "2020-03-30T23:17:53Z",
    "pendingTime": "2020-03-30T23:18:10Z",
    "completionTime": "2020-03-30T23:33:36Z",
    "state": "error",
    "description": "Pod pending timeout.",
    "url": "https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/8023/rehearse-8023-pull-ci-openshift-cluster-image-registry-operator-master-e2e-vsphere/3",
    "pod_name": "aeb8bbeb-72dc-11ea-b31a-0a58ac10118d",
    "build_id": "3",
    "prev_report_states": {
      "gcsk8sreporter": "error",
      "gcsreporter": "error",
      "github-reporter": "error"
    }
  }
}
```