### PR TITLE
prow/types: Make completionTime omitempty

### DIFF
--- a/cmd/search/httpchartpng.go
+++ b/cmd/search/httpchartpng.go
@@ -75,6 +75,10 @@ func (o *options) handleChartPNG(w http.ResponseWriter, req *http.Request) {
 	maxDuration := 0
 	scatters := make([]*scatter, len(index.Search)+4)
 	for _, job := range jobs {
+		if index.Job != nil && !index.Job.MatchString(job.Spec.Job) {
+			continue
+		}
+
 		start, stop := job.Status.StartTime.Time, job.Status.CompletionTime.Time
 		if start.Before(minTime) {
 			continue

--- a/cmd/search/httpchartpng.go
+++ b/cmd/search/httpchartpng.go
@@ -79,7 +79,7 @@ func (o *options) handleChartPNG(w http.ResponseWriter, req *http.Request) {
 			continue
 		}
 
-		start, stop := job.Status.StartTime.Time, job.Status.CompletionTime.Time
+		start, stopPtr := job.Status.StartTime.Time, job.Status.CompletionTime
 		if start.Before(minTime) {
 			continue
 		}
@@ -122,8 +122,9 @@ func (o *options) handleChartPNG(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 
-		if stop.IsZero() {
-			stop = maxTime
+		stop := maxTime
+		if stopPtr != nil {
+			stop = stopPtr.Time
 		}
 
 		dur := int(stop.Sub(start).Seconds())

--- a/cmd/search/jobs.go
+++ b/cmd/search/jobs.go
@@ -24,17 +24,17 @@ func (o *options) handleJobs(w http.ResponseWriter, req *http.Request) {
 	}
 	// sort uncompleted -> newest completed -> oldest completed
 	sort.Slice(jobs, func(i, j int) bool {
-		iTime, jTime := jobs[i].Status.CompletionTime.Time, jobs[j].Status.CompletionTime.Time
-		if iTime.Equal(jTime) {
+		iTime, jTime := jobs[i].Status.CompletionTime, jobs[j].Status.CompletionTime
+		if iTime == nil {
 			return true
 		}
-		if iTime.IsZero() && !jTime.IsZero() {
-			return true
-		}
-		if !iTime.IsZero() && jTime.IsZero() {
+		if jTime == nil {
 			return false
 		}
-		return jTime.Before(iTime)
+		if iTime.Time.Equal(jTime.Time) {
+			return true
+		}
+		return jTime.Time.Before(iTime.Time)
 	})
 	list := prow.JobList{Items: make([]prow.Job, 0, len(jobs))}
 	for _, job := range jobs {

--- a/prow/index.go
+++ b/prow/index.go
@@ -104,7 +104,7 @@ func (s *DiskStore) Handler() cache.ResourceEventHandler {
 			}
 			switch job.Status.State {
 			case "aborted", "error", "failure", "success":
-				if len(job.Status.URL) == 0 || job.Status.CompletionTime.IsZero() {
+				if len(job.Status.URL) == 0 || job.Status.CompletionTime == nil {
 					return false
 				}
 				if s.maxAge > 0 && job.Status.CompletionTime.Time.Add(s.maxAge).Before(time.Now()) {

--- a/prow/indexgcs.go
+++ b/prow/indexgcs.go
@@ -112,7 +112,7 @@ func (r *IndexReader) Run(ctx context.Context, handler cache.ResourceEventHandle
 				Status: JobStatus{
 					State:          state,
 					URL:            statusURL.String(),
-					CompletionTime: metav1.Time{time.Unix(completed, 0)},
+					CompletionTime: &metav1.Time{time.Unix(completed, 0)},
 				},
 			}
 			r.add(job)

--- a/prow/types.go
+++ b/prow/types.go
@@ -26,11 +26,11 @@ type JobSpec struct {
 }
 
 type JobStatus struct {
-	State          string      `json:"state"`
-	StartTime      metav1.Time `json:"startTime"`
-	CompletionTime metav1.Time `json:"completionTime"`
-	URL            string      `json:"url"`
-	BuildID        string      `json:"build_id"`
+	State          string       `json:"state"`
+	StartTime      metav1.Time  `json:"startTime"`
+	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
+	URL            string       `json:"url"`
+	BuildID        string       `json:"build_id"`
 }
 
 func (j Job) DeepCopyObject() runtime.Object {


### PR DESCRIPTION
To match [test-infra][1], fixing a regression introduced by 06c45ec87f (#44).  This fixes the durations for the pending jobs.  The current JavaScript in `cmd/search/httpchart.go` has:

```JavaScript
if (job.status.completionTime === undefined) {
  job.finished = now;
}  else {
  job.finished = isoParse(job.status.completionTime);
}
```

so for pending jobs to get the `now` default, they must have `completionTime` unset.

[1]: https://github.com/kubernetes/test-infra/blob/e35a6bca1f57be69cbe0a24b0b6c076407b2e01f/prow/apis/prowjobs/v1/types.go#L624-L625