### PR TITLE
Fix gcp anonymous auth to work when not running on GCP

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 approvers:
   - smarterclayton
   - wking
+  - stevekuznetsov
+  - alvaroaleman
 reviewers:
   - smarterclayton
   - wking

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -19,6 +19,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
+	gcpoption "google.golang.org/api/option"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -365,7 +366,7 @@ func (o *options) Run() error {
 		if err != nil {
 			klog.Exitf("Unable to build prow client: %v", err)
 		}
-		gcsClient, err := storage.NewClient(context.Background())
+		gcsClient, err := storage.NewClient(context.Background(), gcpoption.WithoutAuthentication())
 		if err != nil {
 			klog.Exitf("Unable to build gcs client: %v", err)
 		}


### PR DESCRIPTION
Currently, this fails with a

```
F0331 19:44:29.926295       1 main.go:370] Unable to build gcs client: dialing: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```

when run outside of GCP. It happens to work on GCP, because there it can fall back to the instance credentials.

/assign @smarterclayton 