### PR TITLE
Go back to using the path index

### DIFF
--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -258,6 +258,7 @@ func renderMatches(ctx context.Context, w io.Writer, index *Index, generator Com
 	}
 
 	count, lineCount, matchCount := 0, 0, 0
+	lines := make([][]byte, 0, 64)
 
 	bw := &sortableWriter{sizeLimit: 2 * 1024 * 1024, bw: bufio.NewWriterSize(w, 256*1024)}
 	var lastName string
@@ -340,9 +341,9 @@ func renderMatches(ctx context.Context, w io.Writer, index *Index, generator Com
 		}
 
 		// remove empty leading and trailing lines
-		var lines [][]byte
+		lines = lines[:]
 		for _, m := range matches {
-			line := bytes.TrimRight(m.Bytes(), " ")
+			line := bytes.TrimRightFunc(m.Bytes(), func(r rune) bool { return r == ' ' })
 			if len(line) == 0 {
 				continue
 			}

--- a/cmd/search/httpsearch.go
+++ b/cmd/search/httpsearch.go
@@ -96,7 +96,7 @@ func (o *options) searchResult(ctx context.Context, index *Index) (map[string]ma
 		}
 
 		for _, m := range matches {
-			line := bytes.TrimRight(m.Bytes(), " ")
+			line := bytes.TrimRightFunc(m.Bytes(), func(r rune) bool { return r == ' ' })
 			match.Context = append(match.Context, string(line))
 		}
 		result[uri][search] = append(result[uri][search], match)

--- a/prow/index.go
+++ b/prow/index.go
@@ -192,10 +192,10 @@ func (s *DiskStore) write(ctx context.Context, job *Job, notifier PathNotifier) 
 	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	if len(parts) < 5 {
-		return nil, fmt.Errorf("job %s URL is not valid: %s", job.Name, job.Status.URL)
+		return nil, nil
 	}
 	if parts[0] != "view" || parts[1] != "gcs" {
-		return nil, fmt.Errorf("job %s URL is not valid: %s", job.Name, job.Status.URL)
+		return nil, nil
 	}
 
 	bucket := parts[2]


### PR DESCRIPTION
Without the path index we are at risk of page cache eviction and
subsequent thrashing when we have to scan the whole directory. To
get back to using the path index we have to support scanning the
input in chunks based on the max path size for fork/exec (lower on
Mac). At the same time, remove a few other common allocators and
streamline the search path.