### PR TITLE
Tolerate the presence of compressed file contents in the index

### DIFF
--- a/cmd/search/grep.go
+++ b/cmd/search/grep.go
@@ -97,13 +97,13 @@ func executeGrepSingle(ctx context.Context, gen CommandGenerator, index *Index, 
 		return err
 	}
 
-	// some platforms siginficantly limit number of arguments - we have to execute in batches
+	// platforms limit the number of arguments - we have to execute in batches
 	var maxArgs int
 	switch runtime.GOOS {
 	case "darwin":
 		maxArgs = 200 * 1024
 	default:
-		maxArgs = 64 * 1024 * 1024
+		maxArgs = 2*1024*1024 - 32*1024
 	}
 	for _, arg := range commandArgs {
 		maxArgs -= len(arg) + 1

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -149,7 +149,7 @@ func (o *options) RipgrepSourceArguments(index *Index) ([]string, []string, erro
 		if paths == nil {
 			if names := o.jobs.FilenamesForSearchType(index.SearchType); len(names) > 0 {
 				for _, name := range names {
-					args = append(args, "--glob", name)
+					args = append(args, "--glob", name+"*")
 				}
 				args = append(args, o.jobsPath)
 			}

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -134,17 +134,24 @@ func (index *pathIndex) Load() error {
 			return nil
 		}
 
-		switch info.Name() {
-		case "build-log.txt", "junit.failures":
-			stats.Entries++
-			stats.Size += info.Size()
-			relPath, err := filepath.Rel(index.base, path)
-			if err != nil {
-				return err
-			}
-			relPath = filepath.ToSlash(relPath)
-			ordered = append(ordered, pathAge{index: info.Name(), path: relPath, age: info.ModTime()})
+		var indexName string
+		switch name := info.Name(); {
+		case strings.HasPrefix(name, "build-log.txt"):
+			indexName = "build-log.txt"
+		case strings.HasPrefix(name, "junit.failures"):
+			indexName = "junit.failures"
+		default:
+			return nil
 		}
+
+		stats.Entries++
+		stats.Size += info.Size()
+		relPath, err := filepath.Rel(index.base, path)
+		if err != nil {
+			return err
+		}
+		relPath = filepath.ToSlash(relPath)
+		ordered = append(ordered, pathAge{index: indexName, path: relPath, age: info.ModTime()})
 
 		return nil
 	})


### PR DESCRIPTION
Allow arbitrary extensions (for gzip, .gz) on the index and correctly
index those results.

Fix linux for excessive command lines by setting to 2M - headroom,
which is 1/4th the stack size on a default system.