### PR TITLE
Cache PNGs for 30s and search fewer results by default

### DIFF
--- a/cmd/search/httpchartpng.go
+++ b/cmd/search/httpchartpng.go
@@ -174,6 +174,7 @@ func (o *options) handleChartPNG(w http.ResponseWriter, req *http.Request) {
 		draw.DrawMask(img, bounds, &image.Uniform{clr}, image.ZP, scatter, image.ZP, draw.Over)
 	}
 
+	w.Header().Set("Cache-Control", "public,max-age=30")
 	w.Header().Set("Content-Type", "image/png")
 	if err = png.Encode(w, img); err != nil {
 		klog.Errorf("Failed to write response: %v", err)

--- a/cmd/search/httpsearch.go
+++ b/cmd/search/httpsearch.go
@@ -51,7 +51,7 @@ func (o *options) searchResult(ctx context.Context, index *Index) (map[string]ma
 	result := map[string]map[string][]*Match{}
 
 	if index.MaxMatches == 0 {
-		index.MaxMatches = 25
+		index.MaxMatches = 1
 	}
 
 	err := executeGrep(ctx, o.generator, index, func(name string, search string, matches []bytes.Buffer, moreLines int) error {


### PR DESCRIPTION
Allow intermediaries to cache the results.