### PR TITLE
Use \x1e as the record separator for comments

### DIFF
--- a/bugzilla/comments.go
+++ b/bugzilla/comments.go
@@ -169,7 +169,7 @@ func (s *CommentStore) run(ctx context.Context, persisted PersistentCommentStore
 		}
 
 		now := time.Now()
-		klog.V(5).Infof("Fetching %d comments", len(bugIDs))
+		klog.V(7).Infof("Fetching %d comments", len(bugIDs))
 		bugComments, err := s.client.BugCommentsByID(ctx, bugIDs...)
 		if err != nil {
 			klog.Warningf("comment store failed to retrieve comments: %v", err)
@@ -213,7 +213,7 @@ func (s *CommentStore) filterComments(bugComments *BugCommentsList) {
 
 func (s *CommentStore) mergeBugs(bugComments *BugCommentsList, now time.Time, persisted PersistentCommentStore) {
 	var total int
-	defer func() { klog.V(5).Infof("Updated %d comment records", total) }()
+	defer func() { klog.V(7).Infof("Updated %d comment records", total) }()
 	s.lock.Lock()
 	defer s.lock.Unlock()
 

--- a/bugzilla/commentsdisk_test.go
+++ b/bugzilla/commentsdisk_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,7 +68,7 @@ func TestCommentDiskStore_write(t *testing.T) {
 				CreationTime: metav1.Time{Time: time.Unix(225, 0)},
 				Time:         metav1.Time{Time: time.Unix(225, 0)},
 				Creator:      "David Doublecomment",
-				Text:         "Fake comment\n---",
+				Text:         "Fake\x1e comment\n---",
 			},
 			{
 				ID:           4,
@@ -105,6 +106,7 @@ func TestCommentDiskStore_write(t *testing.T) {
 
 	// expect the time to be lost (creation time only is sent)
 	comments.Comments[1].Time = comments.Comments[1].CreationTime
+	actualComments.Comments[3].Text = strings.Replace(actualComments.Comments[3].Text, "Fake  ", "Fake\x1e ", 1)
 
 	if !reflect.DeepEqual(comments, actualComments) {
 		t.Fatalf("\n%s", diff.ObjectReflectDiff(comments, actualComments))

--- a/bugzilla/informer.go
+++ b/bugzilla/informer.go
@@ -92,9 +92,9 @@ func (lw *ListWatcher) List(options metav1.ListOptions) (runtime.Object, error) 
 			}
 			list.Continue = strconv.Itoa(args.Offset + int(options.Limit))
 		}
-		klog.V(2).Infof("Listed bugs offset=%d limit=%d total=%d items=%d hasMore=%t nextOffset=%s", args.Offset, options.Limit, returned, len(list.Items), hasMore, list.Continue)
+		klog.V(6).Infof("Listed bugs offset=%d limit=%d total=%d items=%d hasMore=%t nextOffset=%s", args.Offset, options.Limit, returned, len(list.Items), hasMore, list.Continue)
 	} else {
-		klog.V(2).Infof("Listed bugs offset=%d limit=%d total=%d items=%d", args.Offset, options.Limit, len(bugs.Bugs), len(list.Items))
+		klog.V(6).Infof("Listed bugs offset=%d limit=%d total=%d items=%d", args.Offset, options.Limit, len(bugs.Bugs), len(list.Items))
 	}
 	return list, nil
 }
@@ -163,7 +163,7 @@ func (w *periodicWatcher) run() {
 	} else {
 		delay = w.interval
 	}
-	klog.V(5).Infof("Waiting for minimum interval %s", delay)
+	klog.V(6).Infof("Waiting for minimum interval %s", delay)
 	select {
 	case <-time.After(delay):
 	case <-w.done:

--- a/cmd/search/grep.go
+++ b/cmd/search/grep.go
@@ -207,7 +207,7 @@ func runSingleCommand(ctx context.Context, cmd *exec.Cmd, pathPrefix string, ind
 		if n > 0 || (err != nil && err != io.EOF) {
 			klog.Errorf("Unread input %d: %v", n, err)
 		}
-		klog.V(2).Infof("Waiting for command to finish after reading %d lines and %d bytes", linesRead, bytesRead)
+		klog.V(6).Infof("Waiting for command to finish after reading %d lines and %d bytes", linesRead, bytesRead)
 		if err := cmd.Wait(); err != nil {
 			if exitErr, ok := err.(*exec.ExitError); ok && matches == 0 {
 				if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.ExitStatus() == 1 {

--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -350,7 +350,6 @@ func (w *sortableWriter) SetIndex(index int64) {
 	w.index = index
 
 	if w.sizeLimit <= 0 {
-		klog.Infof("DEBUG: results larger than window, flushing from now on")
 		w.buf = nil
 		w.Flush()
 	}

--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -52,15 +52,20 @@ func (o *options) handleConfig(w http.ResponseWriter, req *http.Request) {
 }
 
 func (o *options) handleIndex(w http.ResponseWriter, req *http.Request) {
+	var index *Index
+	var success bool
 	start := time.Now()
-	defer func() { klog.Infof("Render index in %s", time.Now().Sub(start).Truncate(time.Millisecond)) }()
+	defer func() {
+		klog.Infof("Render index %s duration=%s success=%t", index.String(), time.Now().Sub(start).Truncate(time.Millisecond), success)
+	}()
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		flusher = nopFlusher{}
 	}
 
-	index, err := parseRequest(req, "text", o.MaxAge)
+	var err error
+	index, err = parseRequest(req, "text", o.MaxAge)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Bad input: %v", err), http.StatusBadRequest)
 		return
@@ -289,6 +294,8 @@ func (o *options) handleIndex(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(writer, "</div>")
 
 	fmt.Fprintf(writer, htmlPageEnd)
+
+	success = true
 }
 
 func intSelected(current, expected int) string {

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -425,6 +425,8 @@ func (o *options) Run() error {
 		}()
 
 		klog.Infof("Started indexing prow jobs %s", o.DeckURI)
+	} else {
+		o.jobAccessor = prow.Empty
 	}
 
 	go wait.Forever(func() {

--- a/cmd/search/types.go
+++ b/cmd/search/types.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -33,6 +34,8 @@ type Result struct {
 }
 
 type Index struct {
+	Mode string
+
 	// One or more search strings. Some pages support only a single search
 	Search []string
 
@@ -64,12 +67,32 @@ type Index struct {
 	GroupByJob bool
 }
 
+func (i *Index) String() string {
+	if i == nil {
+		return "nil"
+	}
+	sb := &strings.Builder{}
+	sb.WriteRune('{')
+	fmt.Fprintf(sb, "Mode=%s", i.Mode)
+	fmt.Fprintf(sb, " Search=%v", i.Search)
+	fmt.Fprintf(sb, " SearchType=%s", i.SearchType)
+	if i.Job != nil {
+		fmt.Fprintf(sb, " Job=%s", i.Job.String())
+	} else {
+		sb.WriteString(" Job=nil")
+	}
+	sb.WriteRune('}')
+	return sb.String()
+}
+
 func parseRequest(req *http.Request, mode string, maxAge time.Duration) (*Index, error) {
 	if err := req.ParseForm(); err != nil {
 		return nil, err
 	}
 
-	index := &Index{}
+	index := &Index{
+		Mode: mode,
+	}
 
 	index.Search, _ = req.Form["search"]
 	if len(index.Search) == 0 && mode == "chart" {

--- a/prow/index.go
+++ b/prow/index.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -36,12 +34,6 @@ func NewDiskStore(client *storage.Client, path string, maxAge time.Duration) *Di
 		queue:  queue,
 		client: client,
 	}
-}
-
-type JobAccessor interface {
-	Get(name string) (*Job, error)
-	List(labels.Selector) ([]*Job, error)
-	JobStats(name string, names sets.String, from, to time.Time) JobStats
 }
 
 type JobStats struct {

--- a/prow/index.go
+++ b/prow/index.go
@@ -182,7 +182,7 @@ func (s *DiskStore) write(ctx context.Context, job *Job, notifier PathNotifier) 
 	if err := accumulator.MarkCompleted(job.Status.CompletionTime.Time); err != nil {
 		klog.Errorf("Unable to mark job as completed: %v", err)
 	}
-	klog.Infof("Download %s succeeded in %s (%s)", job.Status.URL, time.Now().Sub(start).Truncate(time.Millisecond), job.Status.CompletionTime)
+	klog.V(2).Infof("Download %s succeeded in %s", job.Status.URL, time.Now().Sub(start).Truncate(time.Millisecond))
 	return nil, nil
 }
 

--- a/prow/indexgcs.go
+++ b/prow/indexgcs.go
@@ -159,20 +159,20 @@ func readJobRange(ctx context.Context, bucket *storage.BucketHandle, index strin
 			return err
 		}
 		if stop {
-			klog.Infof("stop: match=%d skip=%d prefix=%s (%s,%s]", match, skip, searchPrefix, fromTimestamp, nextTimestamp)
+			klog.V(6).Infof("stop: match=%d skip=%d prefix=%s (%s,%s]", match, skip, searchPrefix, fromTimestamp, nextTimestamp)
 			break
 		}
 		if done {
-			klog.Infof("done: match=%d skip=%d prefix=%s (%s,%s]", match, skip, searchPrefix, fromTimestamp, nextTimestamp)
+			klog.V(6).Infof("done: match=%d skip=%d prefix=%s (%s,%s]", match, skip, searchPrefix, fromTimestamp, nextTimestamp)
 			break
 		}
-		klog.Infof("read: match=%d skip=%d prefix=%s (%s,%s]", match, skip, searchPrefix, fromTimestamp, nextTimestamp)
+		klog.V(6).Infof("read: match=%d skip=%d prefix=%s (%s,%s]", match, skip, searchPrefix, fromTimestamp, nextTimestamp)
 
 		from = nextFrom
 		fromTimestamp = nextTimestamp
 	}
 
-	klog.Infof("completed in %s with %d scans", time.Now().Sub(start), scans)
+	klog.V(4).Infof("Index completed in %s with %d scans", time.Now().Sub(start), scans)
 	return nil
 }
 

--- a/prow/informer.go
+++ b/prow/informer.go
@@ -33,12 +33,11 @@ func NewLister(indexer cache.Indexer) *Lister {
 	}); err != nil {
 		panic(err)
 	}
-	return &Lister{indexer: indexer, resource: prowGR}
+	return &Lister{indexer: indexer}
 }
 
 type Lister struct {
-	indexer  cache.Indexer
-	resource schema.GroupResource
+	indexer cache.Indexer
 }
 
 func (s *Lister) List(selector labels.Selector) (ret []*Job, err error) {
@@ -54,7 +53,7 @@ func (s *Lister) Get(name string) (*Job, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(s.resource, name)
+		return nil, errors.NewNotFound(prowGR, name)
 	}
 	return obj.(*Job), nil
 }

--- a/prow/informer.go
+++ b/prow/informer.go
@@ -167,7 +167,6 @@ func (lw *ListWatcher) List(options metav1.ListOptions) (runtime.Object, error) 
 		lists = append(lists, list)
 	}
 	merged := mergeJobs(lists)
-	klog.V(4).Infof("Merged into %d results", len(merged.Items))
 	return merged, nil
 }
 

--- a/prow/types.go
+++ b/prow/types.go
@@ -1,9 +1,34 @@
 package prow
 
 import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
+
+type JobAccessor interface {
+	Get(name string) (*Job, error)
+	List(labels.Selector) ([]*Job, error)
+	JobStats(name string, names sets.String, from, to time.Time) JobStats
+}
+
+var Empty JobAccessor = emptyJobAccessor{}
+
+type emptyJobAccessor struct{}
+
+func (emptyJobAccessor) Get(name string) (*Job, error) {
+	return nil, errors.NewNotFound(prowGR, name)
+}
+func (emptyJobAccessor) List(_ labels.Selector) ([]*Job, error) {
+	return nil, nil
+}
+func (emptyJobAccessor) JobStats(name string, names sets.String, from, to time.Time) JobStats {
+	return JobStats{}
+}
 
 type JobList struct {
 	metav1.TypeMeta


### PR DESCRIPTION
The --- construct conflicted with end user separators and was hard to
reason about. Escape any \x1e already in the comments as a space and fix
the e2e test. Also correct an error where Internal Whiteboard was read as
the wrong value.