### PR TITLE
add bz metadata to bz search results

### DIFF
--- a/bugzilla/commentsdisk.go
+++ b/bugzilla/commentsdisk.go
@@ -188,7 +188,7 @@ func (s *CommentDiskStore) write(bug *Bug, comments *BugComments) error {
 
 	if _, err := fmt.Fprintf(
 		w,
-		"Bug %d: %s\nStatus: %s %s\nSeverity: %s\nCreator: %s\nAssigned To: %s\nKeywords: %s\nWhiteboard: %s\nInternal Whiteboard: %s\nEnvironment:%s\n---\n",
+		"Bug %d: %s\nStatus: %s %s\nSeverity: %s\nCreator: %s\nAssigned To: %s\nKeywords: %s\nWhiteboard: %s\nInternal Whiteboard: %s\nTarget Release: %s\nEnvironment:%s\n---\n",
 		bug.Info.ID,
 		lineSafe(bug.Info.Summary),
 		lineSafe(bug.Info.Status),
@@ -199,6 +199,7 @@ func (s *CommentDiskStore) write(bug *Bug, comments *BugComments) error {
 		arrayLineSafe(bug.Info.Keywords, ", "),
 		lineSafe(bug.Info.Whiteboard),
 		lineSafe(bug.Info.InternalWhiteboard),
+		arrayLineSafe(bug.Info.TargetRelease, ", "),
 		lineSafe(strings.ReplaceAll(bug.Info.Environment, "\x0D", "")),
 	); err != nil {
 		f.Close()
@@ -346,10 +347,16 @@ ScanHeader:
 			bug.Info.Whiteboard = parts[1]
 		case strings.HasPrefix(text, "Internal Whiteboard: "):
 			parts := strings.SplitN(text, " ", 3)
-			if len(parts) < 1 || len(parts[1]) == 0 {
+			if len(parts) < 1 || len(parts[2]) == 0 {
 				continue
 			}
 			bug.Info.InternalWhiteboard = parts[2]
+		case strings.HasPrefix(text, "Target Release: "):
+			parts := strings.SplitN(text, " ", 3)
+			if len(parts) < 1 || len(parts[2]) == 0 {
+				continue
+			}
+			bug.Info.TargetRelease = strings.Split(parts[2], ", ")
 		case strings.HasPrefix(text, "Environment: "):
 			parts := strings.SplitN(text, " ", 2)
 			if len(parts) < 1 || len(parts[1]) == 0 {

--- a/bugzilla/types.go
+++ b/bugzilla/types.go
@@ -100,9 +100,10 @@ type BugInfo struct {
 	CreationTime       metav1.Time `json:"creation_time"`
 	LastChangeTime     metav1.Time `json:"last_change_time"`
 	Environment        string      `json:"cf_environment"`
+	TargetRelease      []string    `json:"target_release"`
 }
 
-var bugInfoFields = []string{"id", "status", "resolution", "severity", "priority", "summary", "keywords", "whiteboard", "cf_internal_whiteboard", "creator", "assigned_to", "creation_time", "last_change_time", "cf_environment"}
+var bugInfoFields = []string{"id", "status", "resolution", "severity", "priority", "summary", "keywords", "whiteboard", "cf_internal_whiteboard", "creator", "assigned_to", "creation_time", "last_change_time", "cf_environment", "target_release"}
 
 type SearchBugsArgs struct {
 	LastChangeTime time.Time

--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -19,6 +19,8 @@ import (
 	units "github.com/docker/go-units"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
+
+	"github.com/openshift/ci-search/bugzilla"
 )
 
 type nopFlusher struct{}
@@ -26,12 +28,13 @@ type nopFlusher struct{}
 func (_ nopFlusher) Flush() {}
 
 type Match struct {
-	Name         string      `json:"name,omitempty"`
-	LastModified metav1.Time `json:"lastModified"`
-	FileType     string      `json:"filename"`
-	Context      []string    `json:"context,omitempty"`
-	MoreLines    int         `json:"moreLines,omitempty"`
-	URL          string      `json:"url,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	LastModified metav1.Time       `json:"lastModified"`
+	FileType     string            `json:"filename"`
+	Context      []string          `json:"context,omitempty"`
+	MoreLines    int               `json:"moreLines,omitempty"`
+	URL          string            `json:"url,omitempty"`
+	Bug          *bugzilla.BugInfo `json:"bugInfo,omitempty"`
 }
 
 type SearchResponseResult struct {

--- a/cmd/search/httpsearch.go
+++ b/cmd/search/httpsearch.go
@@ -154,6 +154,7 @@ func (o *options) searchResult(ctx context.Context, index *Index) (map[string]ma
 			FileType:  metadata.FileType,
 			MoreLines: moreLines,
 			Name:      metadata.Name,
+			Bug:       metadata.Bug,
 		}
 
 		for _, m := range matches {

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -223,6 +223,7 @@ func (o *options) MetadataFor(path string) (Result, error) {
 					result.Name = fmt.Sprintf("Bug %d: %s", id, comments.Info.Summary)
 				}
 			}
+			result.Bug = &comments.Info
 		}
 
 		result.IgnoreAge = true

--- a/cmd/search/types.go
+++ b/cmd/search/types.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/ci-search/bugzilla"
 )
 
 type Result struct {
@@ -31,6 +33,8 @@ type Result struct {
 
 	// IgnoreAge is true if the result should be included regardless of age.
 	IgnoreAge bool
+
+	Bug *bugzilla.BugInfo
 }
 
 type Index struct {


### PR DESCRIPTION
with `1772607` as the search string, new results look like:

v2 api:
```
{

    "results": {
        "1772607": {
            "matches": [
                {
                    "name": "Bug 1772607: Mirroring command occasionally throws HTTP 400 when uploading a blob on Quay POST",
                    "lastModified": null,
                    "filename": "bug",
                    "context": [
                        "Bug 1772607: Mirroring command occasionally throws HTTP 400 when uploading a blob on Quay",
                        "Status: POST"
                    ],
                    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1772607",
                    "bugInfo": {
                        "id": 1772607,
                        "status": "POST",
                        "resolution": "",
                        "severity": "low",
                        "priority": "",
                        "summary": "Mirroring command occasionally throws HTTP 400 when uploading a blob on Quay",
                        "keywords": null,
                        "whiteboard": "",
                        "cf_internal_whiteboard": "buildcop",
                        "creator": "vrutkovs@redhat.com",
                        "assigned_to": "somalley@redhat.com",
                        "creation_time": null,
                        "last_change_time": null,
                        "cf_environment": "",
                        "target_release": [
                            "4.6.0"
                        ]
                    }
                },
```

legacy api:
```
{

    "https://bugzilla.redhat.com/show_bug.cgi?id=1772607": {
        "1772607": [
            {
                "name": "Bug 1772607: Mirroring command occasionally throws HTTP 400 when uploading a blob on Quay POST",
                "lastModified": null,
                "filename": "bug",
                "context": [
                    "Bug 1772607: Mirroring command occasionally throws HTTP 400 when uploading a blob on Quay",
                    "Status: POST"
                ],
                "bugInfo": {
                    "id": 1772607,
                    "status": "POST",
                    "resolution": "",
                    "severity": "low",
                    "priority": "",
                    "summary": "Mirroring command occasionally throws HTTP 400 when uploading a blob on Quay",
                    "keywords": null,
                    "whiteboard": "",
                    "cf_internal_whiteboard": "buildcop",
                    "creator": "vrutkovs@redhat.com",
                    "assigned_to": "somalley@redhat.com",
                    "creation_time": null,
                    "last_change_time": null,
                    "cf_environment": "",
                    "target_release": [
                        "4.6.0"
                    ]
                }
            },
```
