### PR TITLE
Some build-log files contain unprintable characters, blocking search

### DIFF
--- a/cmd/search/grep.go
+++ b/cmd/search/grep.go
@@ -38,7 +38,7 @@ type ripgrepGenerator struct {
 }
 
 func (g ripgrepGenerator) Command(index *Index, search string, jobNames sets.String) (string, []string, []string, error) {
-	args := []string{g.execPath, "-z", "-u", "--color", "never", "-S", "--null", "--no-line-number", "--no-heading"}
+	args := []string{g.execPath, "-a", "-z", "-u", "--color", "never", "-S", "--null", "--no-line-number", "--no-heading"}
 	if index.Context >= 0 {
 		args = append(args, "--context", strconv.Itoa(index.Context))
 	} else {


### PR DESCRIPTION
When expanding some log files for openstack the query halted due to an
error extracting content because the log file contained unprintable
characters, and the error message does not match the structure pattern
we need.

```
sh-4.2$ rg -z "layer not known" /var/lib/ci-search/jobs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.5/1285076975131561984/build-log.txt.gz
2704:Jul 20 05:33:53.605 W ns/e2e-statefulset-8408 pod/ss-0 node/rfksxpg3-3c054-qd8tf-worker-vq2ks reason/FailedKillPod error killing pod: failed to "KillContainer" for "webserver" with KillContainerError: "rpc error: code = Unknown desc = failed to unmount container d5a9fc345081d4b2dee3f6318d0656ecfb20ddb8073993b5a07564876b7a95a3: layer not known"
Binary file matches (found "\u{0}" byte around offset 3765373)
```

The actual output segment was:

```00397420  20 20 20 20 20 20 20 31  20 6e 6f 64 65 5f 6c 69  |       1 node_li|
00397430  66 65 63 79 63 6c 65 5f  63 6f 6e 74 72 6f 6c 6c  |fecycle_controll|
00397440  65 72 2e 67 6f 3a 31 34  33 33 5d 20 49 6e 69 74  |er.go:1433] Init|
00397450  69 61 6c 69 7a 69 6e 67  20 65 76 69 63 74 69 6f  |ializing evictio|
00397460  6e 20 6d 65 74 72 69 63  20 66 6f 72 20 7a 6f 6e  |n metric for zon|
00397470  65 3a 20 52 65 67 69 6f  6e 4f 6e 65 3a 00 3a 6e  |e: RegionOne:.:n|
00397480  6f 76 61 0a 49 30 37 32  30 20 30 35 3a 32 35 3a  |ova.I0720 05:25:|
00397490  35 30 2e 39 39 31 32 31  34 20 20 20 20 20 20 20  |50.991214       |
```

and the error was `RegionOne:\x00:nova`

Add `-a` (search files as if they were text) to our ripgrep command.