### PR TITLE
prow: Initial jobs should be underlaid with current jobs

### DIFF
--- a/testgrid/metadata/junit/junit.go
+++ b/testgrid/metadata/junit/junit.go
@@ -97,6 +97,9 @@ func Parse(buf []byte) (Suites, error) {
 	var suites Suites
 	// Try to parse it as a <testsuites/> object
 	err := unmarshalXML(buf, &suites)
+	if err == io.EOF {
+		return suites, nil
+	}
 	if err != nil {
 		// Maybe it is a <testsuite/> object instead
 		suites.Suites = append([]Suite(nil), Suite{})


### PR DESCRIPTION
More recent versions of jobs (by build id and job name) should
override the initial versions from the index, in case there is
more recent data.

The merge logic was excluding completed jobs based on create start
time being older than the window, and that reduced the total set
of visible jobs.

Add metrics that track state of the cache as a user would see it
and also job processing to ensure if we start ignoring lots of
jobs it shows up in the numbers.