### PR TITLE
prow: Don't format junit.failures log output twice

### DIFF
--- a/prow/process.go
+++ b/prow/process.go
@@ -327,7 +327,7 @@ func (a *LogAccumulator) AddSuites(ctx context.Context, suites junit.Suites) {
 				out = *test.Error
 			}
 			fmt.Fprintf(f, "\n\n# %s\n", test.Name)
-			fmt.Fprintf(f, out)
+			fmt.Fprint(f, out)
 		}
 	}
 


### PR DESCRIPTION
The use of `fmt.Fprintf(w, out)` caused `%` in the output to be
escaped, but out is not a format string. Use `fmt.Fprint(w, out)`
instead.