### PR TITLE
Revert "include the classname in the junit test name when populated"

### DIFF
--- a/prow/process.go
+++ b/prow/process.go
@@ -326,12 +326,7 @@ func (a *LogAccumulator) AddSuites(ctx context.Context, suites junit.Suites) {
 			case test.Error != nil:
 				out = *test.Error
 			}
-			if len(test.ClassName) != 0 {
-				fmt.Fprintf(f, "\n\n# %s %s\n", test.ClassName, test.Name)
-			} else {
-				fmt.Fprintf(f, "\n\n# %s\n", test.Name)
-			}
-
+			fmt.Fprintf(f, "\n\n# %s\n", test.Name)
 			fmt.Fprint(f, out)
 		}
 	}


### PR DESCRIPTION
Reverts openshift/ci-search#87

I was wrong.  Or rather i was right initially.  Testgrid is prefixing the testnames w/ "$suitename.", but only in certain circumstances.

reverting this while i continue to investigate the right solution.
