### PR TITLE
metricdb: Disable metric db load when no path specified

### DIFF
--- a/metricdb/db.go
+++ b/metricdb/db.go
@@ -31,7 +31,7 @@ type DB struct {
 }
 
 func New(path string, statusURL url.URL, maxAge time.Duration) (*DB, error) {
-	db, err := sqlx.Open("sqlite", fmt.Sprintf("file:%s?_timeout=3000", path))
+	db, err := sqlx.Open("sqlite", fmt.Sprintf("file:%s?_timeout=3000", url.PathEscape(path)))
 	if err != nil {
 		return nil, fmt.Errorf("unable to open database: %v", err)
 	}

--- a/metricdb/httpgraph/httpgraph.go
+++ b/metricdb/httpgraph/httpgraph.go
@@ -29,6 +29,11 @@ func (g Graph) String() string {
 }
 
 func (s *Server) HandleGraph(w http.ResponseWriter, req *http.Request) {
+	if s.DB == nil {
+		http.Error(w, "Metrics graphing is disabled", http.StatusMethodNotAllowed)
+		return
+	}
+
 	var graph Graph
 	var success bool
 	start := time.Now()
@@ -44,13 +49,8 @@ func (s *Server) HandleGraph(w http.ResponseWriter, req *http.Request) {
 
 	if err := req.ParseForm(); err != nil {
 		http.Error(w, fmt.Sprintf("Bad form input: %v", err), http.StatusBadRequest)
+		return
 	}
-
-	// db, err := s.DB.NewReadConnection()
-	// if err != nil {
-	// 	http.Error(w, fmt.Sprintf("Unable to connect to database: %v", err), http.StatusInternalServerError)
-	// 	return
-	// }
 
 	jobIdsByName := s.DB.JobsByName()
 	jobNamesById := make(map[int64]string)


### PR DESCRIPTION
If the path is not set we can't safely assume the working directory
is writable, which would cause sqlite open to fail. Instead, require
--metric-db to enable storage (read) and --metric-max-age to enable
scraping.

Caused failures to start in ci env