### PR TITLE
metricdb: Periodically refresh static values every large chunk of scrape

### DIFF
--- a/metricdb/db.go
+++ b/metricdb/db.go
@@ -268,7 +268,10 @@ func (d *DB) indexFromGCS(start time.Time) error {
 	if err := index.EachJob(context.TODO(), gcsClient, 0, d.statusURL, func(partialJob prow.Job, attr *storage.ObjectAttrs) error {
 		keysScanned++
 		if keysScanned%1000 == 0 {
-			klog.Infof("DEBUG: Scanned %d job-metrics keys", keysScanned)
+			klog.Infof("Scanned %d job-metrics keys", keysScanned)
+			d.refreshJobCounts()
+			d.refreshJobIdentifiers()
+			d.refreshMetricIdentifiers()
 		}
 
 		jobName, jobNumberString := partialJob.Spec.Job, partialJob.Status.BuildID

--- a/metricdb/httpgraph/httpgraph.go
+++ b/metricdb/httpgraph/httpgraph.go
@@ -169,6 +169,10 @@ const htmlPageStart = `<!DOCTYPE html>
 }
 .input-group-lg > .multiselect-native-select > div.btn-group > .custom-select {
 	font-size: 1.25rem;
+	height: calc(1.5em + 1rem + 2px);
+	line-height: 1.5;
+	padding-top: 8px;
+	padding-bottom: 8px;
 }
 .u-legend {
 	//position: absolute;


### PR DESCRIPTION
Avoid having to wait until the first very large scrape completes.