### PR TITLE
search: Fix the excludeName condition to properly exclude jobs

### DIFF
--- a/cmd/search/types.go
+++ b/cmd/search/types.go
@@ -192,7 +192,7 @@ func parseRequest(req *http.Request, mode string, maxAge time.Duration) (*Index,
 	case includeRE != nil:
 		index.JobFilter = includeRE.MatchString
 	case excludeRE != nil:
-		index.JobFilter = excludeRE.MatchString
+		index.JobFilter = func(name string) bool { return !excludeRE.MatchString(name) }
 	}
 
 	if value := req.FormValue("maxMatches"); len(value) > 0 {


### PR DESCRIPTION
excludeName was behaving as "include" due to copy and paste error.