### PR TITLE
Fix local test failures

### DIFF
--- a/bugzilla/comments_test.go
+++ b/bugzilla/comments_test.go
@@ -44,11 +44,11 @@ func TestCommentStore(t *testing.T) {
 		}
 	}, func(*BugInfo) bool { return true })
 	lister := NewBugLister(informer.GetIndexer())
-	store := NewCommentStore(c, 5*time.Minute, false)
 	diskStore := NewCommentDiskStore(dir, 10*time.Minute)
+	store := NewCommentStore(c, 5*time.Minute, false, diskStore)
 
 	go informer.Run(ctx.Done())
-	go store.Run(ctx, informer, diskStore)
+	go store.Run(ctx, informer)
 	go diskStore.Run(ctx, lister, store, false)
 
 	klog.Infof("waiting for caches to sync")

--- a/bugzilla/commentsdisk.go
+++ b/bugzilla/commentsdisk.go
@@ -170,7 +170,7 @@ func (s *CommentDiskStore) CloseBug(bug *BugComments) error {
 	clone := bug.DeepCopyObject().(*BugComments)
 	clone.Info.Status = "CLOSED"
 	if err := s.write(&Bug{ObjectMeta: clone.ObjectMeta, Info: clone.Info}, clone); err != nil {
-		return fmt.Errorf("could not mark bug %s closed due to write error: %v", clone.Info.ID, err)
+		return fmt.Errorf("could not mark bug %d closed due to write error: %v", clone.Info.ID, err)
 	}
 	return nil
 }

--- a/bugzilla/commentsdisk_test.go
+++ b/bugzilla/commentsdisk_test.go
@@ -96,7 +96,7 @@ func TestCommentDiskStore_write(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("\n%s", string(data))
-	actualComments, err := readBugComments(path, 0)
+	actualComments, err := readBugComments(path)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Local tests were failing because tests weren't updated for new function definitions. Builds would still succeed though. :) 