### PR TITLE
bugzilla: collect version information too

### DIFF
--- a/bugzilla/comments_test.go
+++ b/bugzilla/comments_test.go
@@ -44,11 +44,11 @@ func TestCommentStore(t *testing.T) {
 		}
 	}, func(*BugInfo) bool { return true })
 	lister := NewBugLister(informer.GetIndexer())
-	store := NewCommentStore(c, 5*time.Minute, false)
 	diskStore := NewCommentDiskStore(dir, 10*time.Minute)
+	store := NewCommentStore(c, 5*time.Minute, false, diskStore)
 
 	go informer.Run(ctx.Done())
-	go store.Run(ctx, informer, diskStore)
+	go store.Run(ctx, informer)
 	go diskStore.Run(ctx, lister, store, false)
 
 	klog.Infof("waiting for caches to sync")

--- a/bugzilla/commentsdisk_test.go
+++ b/bugzilla/commentsdisk_test.go
@@ -27,8 +27,14 @@ func TestCommentDiskStore_write(t *testing.T) {
 			Name: "181",
 		},
 		Info: BugInfo{
-			ID:      181,
-			Summary: "Test bug",
+			ID:            181,
+			Status:        "CLOSED",
+			Resolution:    "WORKSFORME",
+			Severity:      "urgent",
+			Summary:       "Test bug",
+			Creator:       "Katherine Johnson",
+			Version:       []string{"4.8"},
+			TargetRelease: []string{"---"},
 		},
 	}
 	comments := &BugComments{
@@ -38,8 +44,14 @@ func TestCommentDiskStore_write(t *testing.T) {
 			CreationTimestamp: metav1.Time{Time: time.Unix(100, 0).Local()},
 		},
 		Info: BugInfo{
-			ID:      181,
-			Summary: "Test bug",
+			ID:            181,
+			Status:        "CLOSED",
+			Resolution:    "WORKSFORME",
+			Severity:      "urgent",
+			Summary:       "Test bug",
+			Creator:       "Katherine Johnson",
+			Version:       []string{"4.8"},
+			TargetRelease: []string{"---"},
 		},
 		Comments: []BugComment{
 			{
@@ -96,7 +108,7 @@ func TestCommentDiskStore_write(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("\n%s", string(data))
-	actualComments, err := readBugComments(path, 0)
+	actualComments, err := readBugComments(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bugzilla/types.go
+++ b/bugzilla/types.go
@@ -102,9 +102,10 @@ type BugInfo struct {
 	LastChangeTime     metav1.Time `json:"last_change_time"`
 	Environment        string      `json:"cf_environment"`
 	TargetRelease      []string    `json:"target_release"`
+	Version            []string    `json:"version"`
 }
 
-var bugInfoFields = []string{"id", "status", "resolution", "severity", "priority", "summary", "keywords", "whiteboard", "cf_internal_whiteboard", "creator", "assigned_to", "creation_time", "last_change_time", "cf_environment", "target_release", "component"}
+var bugInfoFields = []string{"id", "status", "resolution", "severity", "priority", "summary", "keywords", "whiteboard", "cf_internal_whiteboard", "creator", "assigned_to", "creation_time", "last_change_time", "cf_environment", "target_release", "component", "version"}
 
 type SearchBugsArgs struct {
 	LastChangeTime time.Time


### PR DESCRIPTION
This changes search.ci to collect the Version information from Bugzilla
too.  The reason is new bugs in Sippy end up showing as associated, not
linked, to a release.  If Target release is blank (e.g. for a new bug),
I want Sippy to consider the version too. That way new bugs show up
linked.

This also fixes the bugzilla unit tests.