### PR TITLE
Fix metric graph to show the differentiate label values

### DIFF
--- a/metricdb/httpgraph/apigraph.go
+++ b/metricdb/httpgraph/apigraph.go
@@ -172,7 +172,7 @@ func handleAPIJobGraph(req *http.Request, db *sqlx.DB) (*APIJobGraphResponse, st
 			r.job_id = m.job_id AND r.job_id = job.id AND job.name IN (?) AND
 			m.job_number = r.job_number AND 
 			r.type == 'target' 
-		GROUP BY r.job_number
+		GROUP BY r.job_number, m.metric_selector
 		ORDER by r.timestamp, r.version, r.job_id, m.metric_selector;
 		`, metricName, jobNames)
 		if err != nil {


### PR DESCRIPTION
Fix a bug where only one metric was displayed when it had multiple
values with different key/value pairs.

/assign @smarterclayton 