### PR TITLE
Adjust decimal display depending on the metric value

### DIFF
--- a/metricdb/httpgraph/httpgraph.go
+++ b/metricdb/httpgraph/httpgraph.go
@@ -386,9 +386,19 @@ function refresh() {
 			return { width: w, height: w * 1/2,	} 
 		}
 		valueFn = (u, sidx, idx) => {
+			let value = Number(data[sidx][idx])
+			if (value < 1) {
+				value = value.toFixed(3)
+			} else if (value < 10) {
+				value = value.toFixed(2)
+			} else if (value < 100) {
+				value = value.toFixed(1)
+			} else {
+				value = value.toFixed(0)
+			}
 			return {
 				Release: data[data.length-1][idx],
-				Value: Number(data[sidx][idx]).toFixed(1),
+				Value: value,
 			};
 		}
 		series.forEach((el,i) => {


### PR DESCRIPTION
When dealing with latency metrics, values are using second as a unit and
we want to know their value up to the milisecond. So to make it easier
to understand variation on the graph, we will display value up to 3
decimals.

Since the order of magnitude differ depending on the scenario, value < 1
will have 3 decimals displayed, < 10 2 decimals displayed and < 100 1
decimal displayed.

/assign @smarterclayton 