### PR TITLE
jira: use the issue Key instead of ID

### DIFF
--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -268,7 +268,7 @@ func (o *options) handleIndex(w http.ResponseWriter, req *http.Request) {
 				if i := strings.Index(name, ": "); i != -1 {
 					name = name[i+2:]
 				}
-				fmt.Fprintf(bw, "<tr><td><a target=\"_blank\" href=\"%s\">#%d</a></td><td>%s</td><td class=\"text-nowrap\">%s</td><td class=\"col-12\">%s</td></tr>\n", template.HTMLEscapeString(issue.URI.String()), issue.Number, template.HTMLEscapeString(issue.Matches[0].FileType), template.HTMLEscapeString(age), template.HTMLEscapeString(name))
+				fmt.Fprintf(bw, "<tr><td><a class=\"text-nowrap\" target=\"_blank\" href=\"%s\">#%s</a></td><td>%s</td><td class=\"text-nowrap\">%s</td><td class=\"col-12\">%s</td></tr>\n", template.HTMLEscapeString(issue.URI.String()), template.HTMLEscapeString(issue.Key), template.HTMLEscapeString(issue.Matches[0].FileType), template.HTMLEscapeString(age), template.HTMLEscapeString(name))
 				if index.Context >= 0 {
 					fmt.Fprintf(bw, "<tr class=\"row-match\"><td class=\"\" colspan=\"4\"><pre class=\"small\">")
 					for _, match := range issue.Matches {

--- a/cmd/search/httpsearch.go
+++ b/cmd/search/httpsearch.go
@@ -194,6 +194,7 @@ type SearchBugResult struct {
 type SearchIssuesResult struct {
 	Name    string
 	Number  int
+	Key     string
 	URI     *url.URL
 	Matches []Match
 }
@@ -299,6 +300,7 @@ func (o *options) orderedSearchResults(ctx context.Context, index *Index) (*Sear
 			if len(issue.Name) == 0 {
 				issue.Name = metadata.Name
 				issue.URI = metadata.URI
+				issue.Key = metadata.Key
 			}
 			issue.Matches = append(issue.Matches, Match{
 				LastModified: metav1.Time{Time: metadata.LastModified},

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -378,8 +378,9 @@ func (o *options) MetadataFor(path string) (Result, error) {
 		if err != nil {
 			return result, fmt.Errorf("expected path issues/issue__KEY_ID: %s", path)
 		}
-		result.Name = fmt.Sprintf("JiraIssue %d", id)
+		result.Name = fmt.Sprintf("Issue %d", id)
 		result.Number = id
+		result.Key = nameParts[1]
 
 		copied := *o.issueURIPrefix
 		copied.Path = fmt.Sprintf("%s/%s", "browse", nameParts[1])
@@ -395,9 +396,9 @@ func (o *options) MetadataFor(path string) (Result, error) {
 			}
 			if len(comments.Info.Fields.Summary) > 0 {
 				if len(comments.Info.Fields.Status.Name) > 0 {
-					result.Name = fmt.Sprintf("JiraIssue %d: %s %s", id, comments.Info.Fields.Summary, comments.Info.Fields.Status.Name)
+					result.Name = fmt.Sprintf("Issue %s: %s %s", nameParts[1], comments.Info.Fields.Summary, comments.Info.Fields.Status.Name)
 				} else {
-					result.Name = fmt.Sprintf("JiraIssue %d: %s", id, comments.Info.Fields.Summary)
+					result.Name = fmt.Sprintf("Issue %s: %s", nameParts[1], comments.Info.Fields.Summary)
 				}
 			}
 			result.Issue = &comments.Info

--- a/cmd/search/types.go
+++ b/cmd/search/types.go
@@ -38,6 +38,8 @@ type Result struct {
 
 	Bug *bugzilla.BugInfo
 
+	// Key is the identifier of a Jira issue
+	Key string
 	// jira
 	Issue *jiraBaseClient.Issue
 }

--- a/jira/commentsdisk.go
+++ b/jira/commentsdisk.go
@@ -245,8 +245,8 @@ func (s *CommentDiskStore) write(issue *Issue, comments *IssueComments) error {
 
 	if _, err := fmt.Fprintf(
 		w,
-		"JiraIssue %s: %s\nDescription: %s \nStatus: %s\nResolution: %s\nPriority: %s\nCreator: %s\nAssigned To: %s\nLabels: %s\nTarget Version: %s\n---\n",
-		issue.Info.ID,
+		"Issue %s: %s\nDescription: %s \nStatus: %s\nResolution: %s\nPriority: %s\nCreator: %s\nAssigned To: %s\nLabels: %s\nTarget Version: %s\n---\n",
+		issue.Info.Key,
 		lineSafe(issue.Info.Fields.Summary),
 		lineSafe(issue.Info.Fields.Description),
 		statusFieldName(issue.Info.Fields.Status),


### PR DESCRIPTION
The issue ID is used only on the backend, while the UI uses the Key to identify an Issue (e.g. OCPBUGS-12). 

At the current state, the ID is used to identify the issues on the UI of ci-search:
![image](https://user-images.githubusercontent.com/77680331/189714738-6c6ea3e3-bb0e-4f6b-b06e-a2f488776c5a.png)

Since the ID is not indicative for users, this PR changes that to the Key value: 
![image](https://user-images.githubusercontent.com/77680331/189739101-357e3446-7d14-4b83-900e-0da6d31a475b.png)

The same is changed for the REST API. 
