### PR TITLE
bugfix on pathindex

### DIFF
--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -127,14 +127,13 @@ func (index *pathIndex) Load() error {
 			}
 			return err
 		}
+		if info.IsDir() {
+			return nil
+		}
 		if mustExpire && expiredAt.After(info.ModTime()) {
 			os.RemoveAll(path)
 			return nil
 		}
-		if info.IsDir() {
-			return nil
-		}
-
 		var indexName string
 		switch name := info.Name(); {
 		case strings.HasPrefix(name, "build-log.txt"):


### PR DESCRIPTION
The `Load()` method is removing files older than the defined MaxAge, from the prow disk cache.
The `remove` is executed before checking if it is a `dir`. This results in a bug because the entire `jobs` directory is deleted every 14 days (the MaxAge of the files).