### PR TITLE
fix on bugs/issues caching

### DIFF
--- a/bugzilla/commentsdisk.go
+++ b/bugzilla/commentsdisk.go
@@ -137,7 +137,7 @@ func (s *CommentDiskStore) Sync(keys []string) ([]*BugComments, error) {
 			return nil
 		}
 
-		comments, err := readBugComments(path)
+		comments, err := ReadBugComments(path)
 		if err != nil {
 			return fmt.Errorf("unable to read %q: %v", path, err)
 		}
@@ -264,7 +264,7 @@ const (
 	bugCommentDelimiter = "\x1e"
 )
 
-func readBugComments(path string) (*BugComments, error) {
+func ReadBugComments(path string) (*BugComments, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/bugzilla/commentsdisk_test.go
+++ b/bugzilla/commentsdisk_test.go
@@ -108,7 +108,7 @@ func TestCommentDiskStore_write(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("\n%s", string(data))
-	actualComments, err := readBugComments(path)
+	actualComments, err := ReadBugComments(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/jira/commentsdisk.go
+++ b/jira/commentsdisk.go
@@ -140,7 +140,7 @@ func (s *CommentDiskStore) Sync(keys []string) ([]*IssueComments, error) {
 			return nil
 		}
 
-		comments, err := readBugComments(path)
+		comments, err := ReadBugComments(path)
 		if err != nil {
 			return fmt.Errorf("unable to read %q: %v", path, err)
 		}
@@ -308,7 +308,7 @@ const (
 	issueCommentDelimiter = "\x1e"
 )
 
-func readBugComments(path string) (*IssueComments, error) {
+func ReadBugComments(path string) (*IssueComments, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/jira/commentsdisk_test.go
+++ b/jira/commentsdisk_test.go
@@ -131,7 +131,7 @@ func TestCommentDiskStore_write(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("\n%s", string(data))
-	actualComments, err := readBugComments(path)
+	actualComments, err := ReadBugComments(path)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR will fix two presumed incorrectness: 

1. During the initial startup, all bugs and issues from the disk cache are added to the in-mem cache (regardless of the bug/issue status). This behaviour contradicts another, where bugs/issues are removed from the in-mem cache when the bug/issues are removed from the query result (i.e. bugs/issues that have not been updated over the last 14 days or closed ones).

2. If a bug/issue is removed from the in-mem cache, it will not display correctly (screenshot) when searching in the UI. These bugs/issues are as well not included in the results of the `search` API. 

![Screenshot from 2022-11-08 14-44-28](https://user-images.githubusercontent.com/77680331/200621103-aa939de0-ea49-4086-a8ed-2f5fa0b248eb.png)

Detailed description: [OCPCRT-164](https://issues.redhat.com/browse/OCPCRT-164)
