### PR TITLE
add liveness and readiness checks

### DIFF
--- a/cmd/search/http.go
+++ b/cmd/search/http.go
@@ -74,10 +74,6 @@ func (o *options) handleIndex(w http.ResponseWriter, req *http.Request) {
 	var index *Index
 	var success bool
 	start := time.Now()
-	defer func() {
-		klog.Infof("Render index %s duration=%s success=%t", index.String(), time.Now().Sub(start).Truncate(time.Millisecond), success)
-	}()
-
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		flusher = nopFlusher{}
@@ -227,7 +223,9 @@ func (o *options) handleIndex(w http.ResponseWriter, req *http.Request) {
 	// perform a search
 	fmt.Fprintf(writer, `<div style="margin-top: 3rem; position: relative" class="pl-3">`)
 	flusher.Flush()
-
+	defer func() {
+		klog.Infof("Render index %s duration=%s success=%t", index.String(), time.Now().Sub(start).Truncate(time.Millisecond), success)
+	}()
 	switch {
 	case index.GroupByJob:
 		result, err := o.orderedSearchResults(req.Context(), index)

--- a/prow/index.go
+++ b/prow/index.go
@@ -111,12 +111,18 @@ func (s *DiskStore) Handler() cache.ResourceEventHandler {
 	}
 }
 
+func (s *DiskStore) QueueLen() int {
+	return s.queue.Len()
+}
+
 func (s *DiskStore) Run(ctx context.Context, accessor JobAccessor, notifier PathNotifier, disableWrite bool, workers int) {
 	for i := 0; i < workers; i++ {
 		go func(i int) {
 			defer klog.V(2).Infof("Prow disk worker %d exited", i)
 			wait.UntilWithContext(ctx, func(ctx context.Context) {
 				for {
+					// temporary log the queue length
+					klog.Infof("Prow queue length: %d", s.queue.Len())
 					obj, done := s.queue.Get()
 					if done {
 						return


### PR DESCRIPTION
This PR adds liveness and readiness checks. 

For the readiness check, we check if all the informers are synced (Jira, Bugzilla, Prow), and the length of the prow queue.
 
In certain cases, we might need to delete the disk cache. While the Jira and Bugzilla disk cache takes seconds to sync, the Prow one might take up to 40 minutes. 
While the disk cache for prow is being built, we don't want to send traffic to the affected node (to avoid discrepancies in results, depending on which node the user lands). 
While checking for the queue size is not ideal, it will make sure that the vast majority of the Prow jobs are on the disk cache before traffic is routed to the node. 