### PR TITLE
Timestamps when querying Jira must be in EST

### DIFF
--- a/pkg/cmd/jira-watcher-controller/cmd.go
+++ b/pkg/cmd/jira-watcher-controller/cmd.go
@@ -118,7 +118,7 @@ func (o *Options) Run(ctx context.Context) error {
 	jiraInformer := jira.NewInformer(
 		c,
 		10*time.Minute, // Time before watcher starts
-		1*time.Hour,    // How often to resync from jira
+		2*time.Hour,    // How often to resync from jira
 		0,              // Never resync items already in store
 		func(metav1.ListOptions) jira.SearchIssuesArgs {
 			return jira.SearchIssuesArgs{


### PR DESCRIPTION
When the `jira-watcher-controller` began running on the CR cluster, the Watcher was never able to detect that any issues had been updated in-between intervals.  It turns out that the query was looking for issues that have been updated in the future (i.e. UTC time).  This PR specifically sets the "updated" time to EST. 