### PR TITLE
[OCPCRT-310] Remove `status!='CLOSED'` parameter from Query

### DIFF
--- a/pkg/cmd/jira-watcher-controller/cmd.go
+++ b/pkg/cmd/jira-watcher-controller/cmd.go
@@ -38,7 +38,7 @@ func NewJiraWatcherControllerCommand(name string) *cobra.Command {
 	o := &Options{
 		BigQueryRefreshInterval: 1 * time.Minute,
 		JiraURL:                 "https://issues.redhat.com",
-		JiraSearch:              "(project=OCPBUGS&updated>='-14d'&status!='CLOSED'&affectedVersion IN versionMatch('4\\\\.\\\\d+')&level IN (null)) OR (project=TRT&updated>='-14d'&status!='CLOSED'&level IN (null))",
+		JiraSearch:              "(project=OCPBUGS&updated>='-14d'&affectedVersion IN versionMatch('4\\\\.\\\\d+')&level IN (null)) OR (project=TRT&updated>='-14d'&level IN (null))",
 	}
 
 	ccc := controllercmd.NewControllerCommandConfig("jira-watcher-controller", version.Get(), func(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {


### PR DESCRIPTION
Currently, our Jira query processes issues that:

1. `project` is `OCPBUGS`
2. `updated` in the last 14 days
3. `status` is not CLOSED
4. `affectedVersion` in `4.*`
5. `Level` is not set

OR:

1. `project` is `TRT`
2. `updated` in the last 14 days
3. `status` is not CLOSED
4. `Level` is not set

This PR removes the `status` parameter from both sub-queries.