### PR TITLE
Setting default JiraSearch option

### DIFF
--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -53,6 +53,9 @@ func main() {
 		JobURIPrefix:      "https://prow.ci.openshift.org/view/gs/",
 		ArtifactURIPrefix: "https://storage.googleapis.com/",
 		IndexBucket:       "test-platform-results",
+		// JiraSearch: "filter=105522", // CI Search - 30 Days
+		// JiraSearch: "filter=105121", // CI Search - 60 Days
+		JiraSearch: "filter=105523", // CI Search - 90 Days
 	}
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, arguments []string) {


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED