### PR TITLE
Fixing missing ReleaseBlocker values

### DIFF
--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -55,7 +55,9 @@ func main() {
 		IndexBucket:       "test-platform-results",
 		// JiraSearch: "filter=105522", // CI Search - 30 Days
 		// JiraSearch: "filter=105121", // CI Search - 60 Days
-		JiraSearch: "filter=105523", // CI Search - 90 Days
+		// JiraSearch: "filter=105523", // CI Search - 90 Days
+		// TODO: 3/30/2026 - Remove in roughly 90 days (approx 7/1/2026)
+		JiraSearch: "filter=106793", // CI Search - 5 Days
 	}
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, arguments []string) {

--- a/jira/client.go
+++ b/jira/client.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	IssueQaContactField     = "customfield_10470"
-	IssueTargetVersionField = "customfield_10855"
+	IssueQaContactField      = "customfield_10470"
+	IssueTargetVersionField  = "customfield_10855"
+	IssueReleaseBlockerField = "customfield_10847"
 )
 
 // GetUnknownField will attempt to get the specified field from the Unknowns struct and unmarshal
@@ -101,6 +102,25 @@ func IssueTargetVersionIDs(s jiraBaseClient.Issue) []string {
 		listOfTargetVersions = append(listOfTargetVersions, element.ID)
 	}
 	return listOfTargetVersions
+}
+
+type CustomField struct {
+	Self     string `json:"self"`
+	ID       string `json:"id"`
+	Value    string `json:"value"`
+	Disabled bool   `json:"disabled"`
+}
+
+func GetReleaseBlocker(issue *jiraBaseClient.Issue) (*CustomField, error) {
+	var obj *CustomField
+	isSet, err := GetUnknownField(IssueReleaseBlockerField, issue, func() any {
+		obj = &CustomField{}
+		return obj
+	})
+	if !isSet {
+		return nil, err
+	}
+	return obj, err
 }
 
 func FilterPrivateIssues(issue *jiraBaseClient.Issue) bool {

--- a/jira/types.go
+++ b/jira/types.go
@@ -73,7 +73,11 @@ type CommentVisibility struct {
 }
 
 // TODO-check what field is of interest, the rest can be removed
-var issueInfoFields = []string{"created", "priority", "labels", "versions", "assignee", "updated", "status", "components", "summary", "creator", "subtasks", "reporter", "progress", "resolution", "fixVersions", IssueTargetVersionField}
+var issueInfoFields = []string{
+	"created", "priority", "labels", "versions", "assignee", "updated", "status", "components",
+	"summary", "creator", "subtasks", "reporter", "progress", "resolution", "fixVersions",
+	IssueQaContactField, IssueTargetVersionField, IssueReleaseBlockerField,
+}
 
 type SearchIssuesArgs struct {
 	LastChangeTime time.Time

--- a/pkg/cmd/jira-watcher-controller/cmd.go
+++ b/pkg/cmd/jira-watcher-controller/cmd.go
@@ -42,7 +42,9 @@ func NewJiraWatcherControllerCommand(name string) *cobra.Command {
 		BigQueryRefreshInterval: 1 * time.Minute,
 		// JiraSearch: "filter=105522", // CI Search - 30 Days
 		// JiraSearch: "filter=105121", // CI Search - 60 Days
-		JiraSearch: "filter=105523", // CI Search - 90 Days
+		// JiraSearch: "filter=105523", // CI Search - 90 Days
+		// TODO: 3/30/2026 - Remove in roughly 90 days (approx 7/1/2026)
+		JiraSearch: "filter=106793", // CI Search - 5 Days
 	}
 
 	ccc := controllercmd.NewControllerCommandConfig("jira-watcher-controller", version.Get(), func(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {

--- a/pkg/cmd/jira-watcher-controller/types.go
+++ b/pkg/cmd/jira-watcher-controller/types.go
@@ -1,17 +1,18 @@
 package jira_watcher_controller
 
 import (
-	"cloud.google.com/go/bigquery"
 	"encoding/json"
 	"fmt"
-	jiraBaseClient "github.com/andygrunwald/go-jira"
-	"github.com/openshift/ci-search/jira"
-	helpers "github.com/openshift/ci-search/pkg/jira"
-	"k8s.io/klog/v2"
 	"reflect"
 	"slices"
 	"strings"
 	"time"
+
+	"cloud.google.com/go/bigquery"
+	jiraBaseClient "github.com/andygrunwald/go-jira"
+	"github.com/openshift/ci-search/jira"
+	helpers "github.com/openshift/ci-search/pkg/jira"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -352,8 +353,12 @@ func generateBigQueryJson(src interface{}) string {
 }
 
 func getReleaseBlocker(i jiraBaseClient.Issue) ReleaseBlocker {
-	rb, err := helpers.GetReleaseBlocker(&i)
-	if err != nil || rb == nil {
+	rb, err := jira.GetReleaseBlocker(&i)
+	if err != nil {
+		klog.Errorf("failed to parse release blocker for issue %s: %v", i.ID, err)
+		return ReleaseBlocker{}
+	}
+	if rb == nil {
 		return ReleaseBlocker{}
 	}
 	return ReleaseBlocker{

--- a/pkg/jira/helpers.go
+++ b/pkg/jira/helpers.go
@@ -1,16 +1,10 @@
 package jira
 
 import (
-	"encoding/json"
-	"fmt"
 	"strings"
 
 	jiraBaseClient "github.com/andygrunwald/go-jira"
 	jiraClient "sigs.k8s.io/prow/pkg/jira"
-)
-
-const (
-	ReleaseBlockerField = "customfield_10847"
 )
 
 func FilterIssueComments(issueComments *[]jiraBaseClient.Issue) {
@@ -93,45 +87,4 @@ func CommentAuthor(authorDisplayName string) string {
 
 func IssueTargetVersions(s jiraBaseClient.Issue) (*[]*jiraBaseClient.Version, error) {
 	return jiraClient.GetIssueTargetVersion(&s)
-}
-
-type CustomField struct {
-	Self     string `json:"self"`
-	ID       string `json:"id"`
-	Value    string `json:"value"`
-	Disabled bool   `json:"disabled"`
-}
-
-// GetUnknownField will attempt to get the specified field from the Unknowns struct and unmarshal
-// the value into the provided function. If the field is not set, the first return value of this
-// function will return false.
-func getUnknownField(field string, issue *jiraBaseClient.Issue, fn func() any) (bool, error) {
-	obj := fn()
-	if issue.Fields == nil || issue.Fields.Unknowns == nil {
-		return false, nil
-	}
-	unknownField, ok := issue.Fields.Unknowns[field]
-	if !ok {
-		return false, nil
-	}
-	bytes, err := json.Marshal(unknownField)
-	if err != nil {
-		return true, fmt.Errorf("failed to process the custom field %s. Error : %v", field, err)
-	}
-	if err := json.Unmarshal(bytes, obj); err != nil {
-		return true, fmt.Errorf("failed to unmarshal the json to struct for %s. Error: %v", field, err)
-	}
-	return true, nil
-}
-
-func GetReleaseBlocker(issue *jiraBaseClient.Issue) (*CustomField, error) {
-	var obj *CustomField
-	isSet, err := getUnknownField(ReleaseBlockerField, issue, func() any {
-		obj = &CustomField{}
-		return obj
-	})
-	if !isSet {
-		return nil, err
-	}
-	return obj, err
 }


### PR DESCRIPTION
It was brought to my attention that the `ReleaseBlocker` fields have not been populating, in the BigQuery table, since we migrated from DC to Jira Cloud.  The reason is because we used to get all the relevant fields by default before and now we need to specify the ones we want.

This PR unifies all the `customfield` parameters into a single place and adds the necessary fields into `issueInfoFields` to ensure that their values are returned when we get the issues.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED