### PR TITLE
OCPCRT-635: fix disk GC gaps and remove dead code causing PVC file growth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 coverage.out
 golangci-lint.out
 report.json
+.dccache

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - vendor/**
+    - "**/*_test.go"

--- a/bugzilla/comments.go
+++ b/bugzilla/comments.go
@@ -33,6 +33,10 @@ type CommentStore struct {
 	lock sync.Mutex
 }
 
+// diskSyncInterval controls how often the persisted comment store is garbage
+// collected for expired and orphaned files.
+const diskSyncInterval = 15 * time.Minute
+
 type PersistentCommentStore interface {
 	Sync(keys []string) ([]*BugComments, error)
 	NotifyChanged(id int)
@@ -117,6 +121,20 @@ func (s *CommentStore) Run(ctx context.Context, informer cache.SharedInformer) e
 		}
 		klog.V(5).Infof("Refreshed %d comments older than %s", count, s.refreshInterval.String())
 	}, s.refreshInterval/4)
+
+	// periodically garbage collect expired and orphaned files from disk. The initial
+	// Sync above only runs once at startup, so without this a long-running process
+	// never reclaims disk space for bugs that age out after boot.
+	if s.persistedStore != nil {
+		go wait.UntilWithContext(ctx, func(ctx context.Context) {
+			list, err := s.persistedStore.Sync(nil)
+			if err != nil {
+				klog.Errorf("Unable to garbage collect persisted bug comments: %v", err)
+				return
+			}
+			klog.V(4).Infof("Garbage collected persisted bug comments, %d remain", len(list))
+		}, diskSyncInterval)
+	}
 
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		if err := s.run(ctx); err != nil {

--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -676,7 +676,7 @@ func (o *options) Run() error {
 		go informer.Run(ctx.Done())
 		go func() {
 			cache.WaitForCacheSync(ctx.Done(), informer.HasSynced)
-			store.Run(ctx, lister, indexedPaths, o.NoIndex, 40)
+			store.Run(ctx, lister, o.NoIndex, 40)
 		}()
 
 		klog.Infof("Started indexing prow jobs %s", o.DeckURI)

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -132,6 +132,15 @@ func (index *pathIndex) Load() error {
 		}
 		if mustExpire && expiredAt.After(info.ModTime()) {
 			os.RemoveAll(path)
+			// each job build has its own directory (jobs/<job>/<build-id>/...) that is
+			// never reused once written, so once its files have expired the directory
+			// itself is safe to remove. os.Remove only succeeds when the directory is
+			// empty, so this is a no-op if other files remain.
+			if dir := filepath.Dir(path); dir != index.base {
+				if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
+					klog.V(6).Infof("Could not remove empty job directory %s: %v", dir, err)
+				}
+			}
 			return nil
 		}
 		var indexName string

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -128,7 +128,10 @@ func (index *pathIndex) Load() error {
 			return nil
 		}
 		if mustExpire && expiredAt.After(info.ModTime()) {
-			os.RemoveAll(path)
+			if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+				klog.Errorf("Could not remove expired file %s: %v", path, err)
+				return nil
+			}
 			// each job build has its own directory (jobs/<job>/<build-id>/...) that is
 			// never reused once written, so once its files have expired the directory
 			// itself is safe to remove. os.Remove only succeeds when the directory is

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -103,9 +103,6 @@ func (index *pathIndex) LastModified(path string) time.Time {
 	return time.Time{}
 }
 
-func (index *pathIndex) Notify(paths []string) {
-}
-
 func (index *pathIndex) Load() error {
 	ordered := make([]pathAge, 0, 1024)
 

--- a/jira/comments.go
+++ b/jira/comments.go
@@ -35,6 +35,10 @@ type CommentStore struct {
 	lock sync.Mutex
 }
 
+// diskSyncInterval controls how often the persisted comment store is garbage
+// collected for expired and orphaned files.
+const diskSyncInterval = 15 * time.Minute
+
 type PersistentCommentStore interface {
 	Sync(keys []string) ([]*IssueComments, error)
 	NotifyChanged(id int)
@@ -115,6 +119,20 @@ func (s *CommentStore) Run(ctx context.Context, informer cache.SharedInformer) e
 		}
 		klog.V(5).Infof("Refreshed %d comments older than %s", count, s.refreshInterval.String())
 	}, s.refreshInterval/4)
+
+	// periodically garbage collect expired and orphaned files from disk. The initial
+	// Sync above only runs once at startup, so without this a long-running process
+	// never reclaims disk space for issues that age out after boot.
+	if s.persistedStore != nil {
+		go wait.UntilWithContext(ctx, func(ctx context.Context) {
+			list, err := s.persistedStore.Sync(nil)
+			if err != nil {
+				klog.Errorf("Unable to garbage collect persisted issue comments: %v", err)
+				return
+			}
+			klog.V(4).Infof("Garbage collected persisted issue comments, %d remain", len(list))
+		}, diskSyncInterval)
+	}
 
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		if err := s.run(ctx); err != nil {

--- a/prow/index.go
+++ b/prow/index.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -66,10 +64,6 @@ type JobStats struct {
 	Failures int
 }
 
-type PathNotifier interface {
-	Notify(paths []string)
-}
-
 func (s *DiskStore) Handler() cache.ResourceEventHandler {
 	return cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
@@ -115,7 +109,7 @@ func (s *DiskStore) QueueLen() int {
 	return s.queue.Len()
 }
 
-func (s *DiskStore) Run(ctx context.Context, accessor JobAccessor, notifier PathNotifier, disableWrite bool, workers int) {
+func (s *DiskStore) Run(ctx context.Context, accessor JobAccessor, disableWrite bool, workers int) {
 	for i := 0; i < workers; i++ {
 		go func(i int) {
 			defer klog.V(2).Infof("Prow disk worker %d exited", i)
@@ -145,8 +139,7 @@ func (s *DiskStore) Run(ctx context.Context, accessor JobAccessor, notifier Path
 					ctx, cancelFn := context.WithTimeout(ctx, time.Minute)
 					func() {
 						defer cancelFn()
-						paths, err := s.write(ctx, job, notifier)
-						if err != nil {
+						if err := s.write(ctx, job); err != nil {
 							if s.queue.NumRequeues(obj) > 5 {
 								s.queue.Forget(obj)
 							} else {
@@ -156,7 +149,6 @@ func (s *DiskStore) Run(ctx context.Context, accessor JobAccessor, notifier Path
 							klog.Errorf("failed to write job: %v", err)
 							return
 						}
-						notifier.Notify(paths)
 						s.queue.Done(id)
 					}()
 				}
@@ -166,28 +158,28 @@ func (s *DiskStore) Run(ctx context.Context, accessor JobAccessor, notifier Path
 	<-ctx.Done()
 }
 
-func (s *DiskStore) write(ctx context.Context, job *Job, notifier PathNotifier) ([]string, error) {
+func (s *DiskStore) write(ctx context.Context, job *Job) error {
 	if job.Status.State == "error" && job.Status.URL == "https://github.com/kubernetes/test-infra/issues" {
 		metricScrapedJobsIgnored.Add(1)
-		return nil, nil
+		return nil
 	}
 	u, err := url.Parse(job.Status.URL)
 	if err != nil {
 		metricScrapedJobsFailed.Add(1)
-		return nil, fmt.Errorf("job %s has no valid status URL: %v", job.Name, err)
+		return fmt.Errorf("job %s has no valid status URL: %v", job.Name, err)
 	}
 
 	bucket, _, _, _, parts, err := jobPathToAttributes(u.Path, job.Status.URL)
 	if err != nil {
 		metricScrapedJobsFailed.Add(1)
-		return nil, err
+		return err
 	}
 	if len(bucket) == 0 {
 		// This typically indicates that Prow changed in an unexpected way, perhaps by altering the
 		// URL it reports to jobs.
 		klog.Infof("Job URL cannot be indexed, does not match expected structure: %s", job.Status.URL)
 		metricScrapedJobsIgnored.Add(1)
-		return nil, nil
+		return nil
 	}
 
 	build := Build{
@@ -200,12 +192,12 @@ func (s *DiskStore) write(ctx context.Context, job *Job, notifier PathNotifier) 
 	accumulator, stale := NewAccumulator(s.base, &build, job.Status.CompletionTime.Time)
 	if !stale {
 		klog.V(7).Infof("Job %s is up to date", job.Status.URL)
-		return nil, nil
+		return nil
 	}
 	if err := ReadBuild(build, accumulator); err != nil {
 		klog.Infof("Download %s failed in %s: %v", job.Status.URL, time.Now().Sub(start).Truncate(time.Millisecond), err)
 		metricScrapedJobsFailed.Add(1)
-		return nil, err
+		return err
 	}
 	if err := accumulator.MarkCompleted(job.Status.CompletionTime.Time); err != nil {
 		klog.Errorf("Unable to mark job as completed: %v", err)
@@ -213,40 +205,11 @@ func (s *DiskStore) write(ctx context.Context, job *Job, notifier PathNotifier) 
 	}
 	klog.V(2).Infof("Download %s succeeded in %s", job.Status.URL, time.Now().Sub(start).Truncate(time.Millisecond))
 	metricScrapedJobs.Add(1)
-	return nil, nil
-}
-
-func (s *DiskStore) pathForJob(job *Job) string {
-	return filepath.Join(s.base, job.Spec.Job, job.Status.BuildID)
+	return nil
 }
 
 func (s *DiskStore) notifyChanged(id string) {
 	s.queue.Add(id)
-}
-
-func (s *DiskStore) Sync() error {
-	start := time.Now()
-	mustExpire := s.maxAge != 0
-	expiredAt := start.Add(-s.maxAge)
-
-	return filepath.Walk(s.base, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-		if info.IsDir() {
-			return nil
-		}
-
-		if mustExpire && expiredAt.After(info.ModTime()) {
-			os.Remove(path)
-			klog.V(5).Infof("File expired: %s", path)
-			return nil
-		}
-		return nil
-	})
 }
 
 func jobPathToAttributes(path, full string) (bucket, trigger, job, buildID string, parts []string, err error) {


### PR DESCRIPTION
## Summary
A pod restart required an fsGroup-driven recursive permission fix-up over ~4 million files on the ci-search PVC, causing a very slow startup. Investigation traced this to gaps in the on-disk cache's garbage collection, plus a dead, never-called GC implementation that duplicated the live one.

- `pathIndex.Load()` now removes a job's now-empty build-id directory after its expired files are pruned, instead of leaving it orphaned forever.
- `bugzilla`/`jira` `CommentStore.Run()` now periodically re-runs the persisted store's `Sync()` (every 15m) instead of only once at startup, so long-lived pods keep reclaiming space for expired bugs/issues.
- Removed `prow.DiskStore.Sync()` (unused since it was introduced in 2020, duplicated `pathIndex.Load()`, never called), the no-op `PathNotifier`/`Notify` plumbing that fed it, and the unused `pathForJob()` helper.

Note: the recursive chown on pod start is a Kubernetes/OpenShift `fsGroup` behavior controlled by the Deployment/StatefulSet spec in the separate deploy repo; recommended fix there is `securityContext.fsGroupChangePolicy: OnRootMismatch`, tracked separately from this PR.

Jira: https://issues.redhat.com/browse/OCPCRT-635

## Test plan
- [x] `go build -mod vendor ./...`
- [x] `go vet -mod vendor ./...`
- [x] `go test -mod vendor ./...` (all packages with tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic cleanup of expired and orphaned comment data.
  * Removed obsolete search files and job directories after index entries expire.
  * Improved handling of outdated or already-current records during background processing.
  * Added safer handling for file-removal errors during index expiration.

* **Maintenance**
  * Background synchronization now runs periodically to keep persisted data stores clean.
  * Simplified background indexing and storage maintenance behavior.
  * Updated security scanning exclusions for vendored code and test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->