### PR TITLE
OCPCRT-639: reclaim empty job directories via a separate disk-GC loop

### DIFF
--- a/cmd/search/main.go
+++ b/cmd/search/main.go
@@ -50,6 +50,7 @@ func main() {
 	opt := &options{
 		ListenAddr:        ":8080",
 		MaxAge:            14 * 24 * time.Hour,
+		DiskGCInterval:    time.Hour,
 		JobURIPrefix:      "https://prow.ci.openshift.org/view/gs/",
 		ArtifactURIPrefix: "https://storage.googleapis.com/",
 		IndexBucket:       "test-platform-results",
@@ -74,6 +75,7 @@ func main() {
 	flags.AddGoFlag(original.Lookup("v"))
 
 	flags.DurationVar(&opt.MaxAge, "max-age", opt.MaxAge, "The maximum age of entries to keep cached. Set to 0 to keep all. Defaults to 14 days.")
+	flags.DurationVar(&opt.DiskGCInterval, "disk-gc-interval", opt.DiskGCInterval, "How often to sweep the jobs cache for empty directories left behind by expired files and remove them. Set to 0 to disable. Defaults to 1 hour.")
 	flags.DurationVar(&opt.Interval, "interval", opt.Interval, "(Disabled) The interval to index jobs.")
 	flags.StringVar(&opt.ConfigPath, "config", opt.ConfigPath, "(Disabled) Path on disk to a testgrid config for indexing.")
 	flags.StringVar(&opt.GCPServiceAccount, "gcp-service-account", opt.GCPServiceAccount, "(Disabled) Path to a GCP service account file.")
@@ -109,6 +111,7 @@ type options struct {
 
 	// arguments to indexing
 	MaxAge            time.Duration
+	DiskGCInterval    time.Duration
 	Interval          time.Duration
 	GCPServiceAccount string
 	JobURIPrefix      string
@@ -703,6 +706,18 @@ func (o *options) Run() error {
 			klog.Fatalf("Unable to index: %v", err)
 		}
 	}, 3*time.Minute)
+
+	// Reclaim empty directories left behind by expired files on a slower cadence,
+	// independent of the search-index refresh above. Errors are logged rather than
+	// fatal so a transient filesystem issue never takes down the server.
+	if o.DiskGCInterval > 0 {
+		klog.Infof("Empty job directories are pruned every %s", o.DiskGCInterval)
+		go wait.Forever(func() {
+			if _, err := indexedPaths.PruneEmptyDirs(); err != nil {
+				klog.Errorf("Unable to prune empty job directories: %v", err)
+			}
+		}, o.DiskGCInterval)
+	}
 
 	o.generator, err = NewCommandGenerator(o.Path, o)
 	if err != nil {

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -235,8 +235,9 @@ func (index *pathIndex) PruneEmptyDirs() (removed int, err error) {
 		if err := os.Remove(dir); err != nil {
 			// ENOTEMPTY simply means the directory still holds files or
 			// not-yet-stale children; that is expected and not worth logging.
+			// Anything else (permission, I/O) is unexpected and logged loudly.
 			if !os.IsNotExist(err) && !errors.Is(err, syscall.ENOTEMPTY) {
-				klog.V(4).Infof("Could not remove empty job directory %s: %v", dir, err)
+				klog.Errorf("Could not remove empty job directory %s: %v", dir, err)
 			}
 			continue
 		}

--- a/cmd/search/pathindex.go
+++ b/cmd/search/pathindex.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -128,18 +130,12 @@ func (index *pathIndex) Load() error {
 			return nil
 		}
 		if mustExpire && expiredAt.After(info.ModTime()) {
+			// Only expired files are removed here; the empty directories they leave
+			// behind are reclaimed separately by PruneEmptyDirs. Deleting a file
+			// bumps its parent directory's mtime to the deletion time, so an
+			// age-based cutoff can never catch those directories.
 			if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
 				klog.Errorf("Could not remove expired file %s: %v", path, err)
-				return nil
-			}
-			// each job build has its own directory (jobs/<job>/<build-id>/...) that is
-			// never reused once written, so once its files have expired the directory
-			// itself is safe to remove. os.Remove only succeeds when the directory is
-			// empty, so this is a no-op if other files remain.
-			if dir := filepath.Dir(path); dir != index.base {
-				if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
-					klog.V(6).Infof("Could not remove empty job directory %s: %v", dir, err)
-				}
 			}
 			return nil
 		}
@@ -184,6 +180,69 @@ func (index *pathIndex) Load() error {
 	index.stats = stats
 
 	return nil
+}
+
+// emptyDirGracePeriod is how long a directory must have gone untouched before
+// PruneEmptyDirs will remove it. The DiskStore writer creates a build directory
+// (os.MkdirAll) before downloading and writing its files, so a directory that is
+// still empty this long after its last modification is treated as orphaned (its
+// files aged out) rather than mid-write. It must stay well below --max-age.
+const emptyDirGracePeriod = 30 * time.Minute
+
+// PruneEmptyDirs walks the index base and removes empty directories bottom-up,
+// reclaiming the build/job/PR directories left behind after Load removes expired
+// files. Directory age relative to --max-age is intentionally ignored: deleting a
+// build's last file bumps that directory's mtime to the deletion time, so an
+// age-based cutoff would never catch recently-emptied directories. Instead any
+// directory left empty and untouched for emptyDirGracePeriod is removed.
+//
+// Directories are removed deepest-first (a child path is always longer than its
+// parent) so a chain of now-empty ancestors collapses fully in a single pass;
+// os.Remove only succeeds on an empty directory, so populated directories are
+// left untouched.
+func (index *pathIndex) PruneEmptyDirs() (removed int, err error) {
+	start := time.Now()
+	staleBefore := start.Add(-emptyDirGracePeriod)
+
+	dirs := make([]string, 0, 1024)
+	defer func() {
+		klog.Infof("Pruned %d empty job directories (of %d candidates) in %s: %v", removed, len(dirs), time.Now().Sub(start).Truncate(time.Millisecond), err)
+	}()
+
+	err = walk.Walk(index.base, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if info.IsDir() && path != index.base && staleBefore.After(info.ModTime()) {
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Remove deepest directories first so that emptied parents become removable
+	// within the same pass. A child path is always longer than its parent, so
+	// ordering by descending path length guarantees children are visited first.
+	sort.Slice(dirs, func(i, j int) bool {
+		return len(dirs[i]) > len(dirs[j])
+	})
+	for _, dir := range dirs {
+		if err := os.Remove(dir); err != nil {
+			// ENOTEMPTY simply means the directory still holds files or
+			// not-yet-stale children; that is expected and not worth logging.
+			if !os.IsNotExist(err) && !errors.Is(err, syscall.ENOTEMPTY) {
+				klog.V(4).Infof("Could not remove empty job directory %s: %v", dir, err)
+			}
+			continue
+		}
+		removed++
+	}
+	return removed, nil
 }
 
 func (i *pathIndex) FilenamesForSearchType(searchType string) []string {

--- a/cmd/search/pathindex_test.go
+++ b/cmd/search/pathindex_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPruneEmptyDirs(t *testing.T) {
+	base := t.TempDir()
+	old := time.Now().Add(-2 * emptyDirGracePeriod)
+
+	mkdir := func(rel string, mtime time.Time) string {
+		p := filepath.Join(base, filepath.FromSlash(rel))
+		if err := os.MkdirAll(p, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(p, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	writeFile := func(rel string) {
+		p := filepath.Join(base, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A populated build directory: must survive along with its ancestors.
+	writeFile("logs/job-a/1/junit.failures")
+	// A chain of empty, aged-out directories: must collapse entirely.
+	emptyChain := mkdir("logs/job-b/2", old)
+	// An empty but recently-touched directory: must be left alone (writer race guard).
+	freshEmpty := mkdir("logs/job-c/3", time.Now())
+	// Make the parents of the aged-out leaf aged-out too so the whole chain is eligible.
+	if err := os.Chtimes(filepath.Join(base, "logs", "job-b"), old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	index := &pathIndex{base: base}
+	removed, err := index.PruneEmptyDirs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Removed: logs/job-b/2 and logs/job-b (two empty dirs collapsed bottom-up).
+	if removed != 2 {
+		t.Errorf("expected 2 removed directories, got %d", removed)
+	}
+
+	if _, err := os.Stat(emptyChain); !os.IsNotExist(err) {
+		t.Errorf("expected empty aged-out chain %s to be removed, err=%v", emptyChain, err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "logs", "job-b")); !os.IsNotExist(err) {
+		t.Errorf("expected empty parent job-b to be removed")
+	}
+	if _, err := os.Stat(freshEmpty); err != nil {
+		t.Errorf("expected recently-touched empty dir %s to survive, err=%v", freshEmpty, err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "logs", "job-a", "1", "junit.failures")); err != nil {
+		t.Errorf("expected populated directory to survive, err=%v", err)
+	}
+	if _, err := os.Stat(base); err != nil {
+		t.Errorf("expected base directory to survive, err=%v", err)
+	}
+}


### PR DESCRIPTION
## What / Why

Follow-up to OCPCRT-635. File-level GC in the jobs cache works (0 files older than `--max-age` on the running pod), but the **directories** left behind after files expire were never reclaimed. `pathIndex.Load()` only removed an expired file's *immediate* parent, and only in the pass the file was deleted — so already-empty dirs and every empty ancestor were stranded forever.

On `search-0` (`/var/lib/ci-search/jobs`):

| Metric | Count |
|---|---|
| Total directories | 564,084 |
| Empty directories | **312,079 (55%)** |
| Total files | 226,190 |
| Files older than 14 days | 0 |

This inflates the PVC directory/inode count and worsens the fsGroup recursive permission fix-up slow-start described in OCPCRT-635.

An **age-based directory cutoff cannot fix this**: deleting a build's last file bumps that directory's mtime to the deletion time, so recently-emptied dirs masquerade as fresh (263k of the 312k empty dirs looked "newer than 14 days").

## Changes

- **`pathIndex.PruneEmptyDirs()`** — sweeps the base and removes empty directories **bottom-up** (deepest path first, since a child path is always longer than its parent), collapsing whole orphaned `build-id → job → pr → org_repo` chains in a single pass. `os.Remove` only succeeds on empty dirs, so populated ones are untouched. Gated only by a 30m grace period guarding the writer's `MkdirAll`→download→`Create` race — **not** by `--max-age`.
- **Separate, tunable loop** — `--disk-gc-interval` (default `1h`, `0` to disable). Crash-isolated: errors are logged (non-fatal), unlike the `Load()` index refresh which is `klog.Fatalf`.
- **Simplified `Load()`** — now prunes only expired files; directory reclamation belongs to `PruneEmptyDirs`.
- Added `pathindex_test.go` covering bottom-up collapse, populated-dir preservation, and the grace-period guard.

## Immediate remediation (backlog)

The code cleans up an hour at a time going forward. To reclaim the existing 312k-dir backlog immediately:

```sh
oc -n crt-argocd rsh search-0 \
  find /var/lib/ci-search/jobs -depth -mindepth 1 -type d -empty -delete
```

## Testing

`make build`, `go vet`, and `go test ./cmd/search/...` all pass.

Jira: https://issues.redhat.com/browse/OCPCRT-639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of empty job directories on a configurable schedule, independently of index refreshes.
  * Added the `--disk-gc-interval` option, defaulting to one hour; set it to `0` to disable cleanup.
* **Bug Fixes**
  * Cleanup now safely removes stale empty directories while preserving active, recently used, and populated directories.
  * Cleanup errors are logged without stopping the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->